### PR TITLE
fix: correct Docker image URLs and tags across all docs

### DIFF
--- a/DOCKERHUB_README.md
+++ b/DOCKERHUB_README.md
@@ -1,7 +1,7 @@
 # AI ReviewBot
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/konstziv/ai-reviewbot)](https://hub.docker.com/r/konstziv/ai-reviewbot)
-[![Docker Image Size](https://img.shields.io/docker/image-size/konstziv/ai-reviewbot/latest)](https://hub.docker.com/r/konstziv/ai-reviewbot)
+[![Docker Image Size](https://img.shields.io/docker/image-size/konstziv/ai-reviewbot/1)](https://hub.docker.com/r/konstziv/ai-reviewbot)
 [![GitHub](https://img.shields.io/github/license/KonstZiv/ai-code-reviewer)](https://github.com/KonstZiv/ai-code-reviewer)
 
 AI-powered code review tool for GitHub and GitLab with **inline suggestions** and "Apply" button support.
@@ -21,7 +21,7 @@ AI-powered code review tool for GitHub and GitLab with **inline suggestions** an
 
 ```yaml
 ai-review:
-  image: konstziv/ai-reviewbot:latest
+  image: konstziv/ai-reviewbot:1
   script:
     - ai-review
   rules:
@@ -39,7 +39,7 @@ docker run --rm \
   -e GITHUB_TOKEN="your-token" \
   -e GITHUB_REPOSITORY="owner/repo" \
   -e GITHUB_EVENT_NUMBER="123" \
-  konstziv/ai-reviewbot:latest
+  konstziv/ai-reviewbot:1
 ```
 
 ## Environment Variables
@@ -56,9 +56,9 @@ docker run --rm \
 
 ## Tags
 
-- `latest` — Latest stable release
-- `1.0.0`, `1.0`, `1` — Specific versions
+- `1.0.0`, `1.0`, `1` — Specific versions (recommended)
 - `1.0.0a1` — Alpha/pre-release versions
+- `latest` — Latest stable release (available after v1.0.0)
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: konstziv/ai-reviewbot:latest
+  image: konstziv/ai-reviewbot:1
   script:
     - ai-review
   rules:
@@ -84,10 +84,10 @@ ai-review --repo owner/repo --pr 123
 
 ```bash
 # DockerHub
-docker pull konstziv/ai-reviewbot:latest
+docker pull konstziv/ai-reviewbot:1
 
 # GitHub Container Registry
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 ```
 
 ## 📖 Documentation
@@ -123,44 +123,33 @@ The reviewer provides structured feedback with inline suggestions:
 
 ### Summary Comment
 
-````markdown
-## 🤖 AI Code Review
-
-### 📊 Summary
-Found 2 issues and 1 good practice.
-
-| Category | Critical | Warning | Info |
-|----------|----------|---------|------|
-| Security | 1 | 0 | 0 |
-| Code Quality | 0 | 1 | 0 |
-
-### ✨ Good Practices
-✅ Excellent error handling in `api/handlers.py`
-
----
-⏱️ 1.2s | 🪙 1,540 tokens | 💰 ~$0.002
-````
+> **🤖 AI Code Review**
+>
+> **📊 Summary** — Found 2 issues and 1 good practice.
+>
+> | Category | Critical | Warning | Info |
+> |----------|----------|---------|------|
+> | Security | 1 | 0 | 0 |
+> | Code Quality | 0 | 1 | 0 |
+>
+> **✨ Good Practices** — Excellent error handling in `api/handlers.py`
+>
+> ---
+> ⏱️ 1.2s | 🪙 1,540 tokens | 💰 ~$0.002
 
 ### Inline Comment with "Apply" Button
 
-````markdown
-⚠️ **SQL Injection Risk**
-
-User input is concatenated directly into SQL query.
-
-```suggestion
-cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))
-```
-
-<details>
-<summary>💡 Why this matters</summary>
-
-SQL injection allows attackers to execute arbitrary SQL commands.
-Always use parameterized queries.
-
-📚 [Learn more](https://owasp.org/www-community/attacks/SQL_Injection)
-</details>
-````
+> ⚠️ **SQL Injection Risk**
+>
+> User input is concatenated directly into SQL query.
+>
+> ```suggestion
+> cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+> ```
+>
+> 💡 **Why this matters:** SQL injection allows attackers to execute arbitrary SQL commands. Always use parameterized queries.
+>
+> 📚 [Learn more](https://owasp.org/www-community/attacks/SQL_Injection)
 
 ## 🛠️ Development
 

--- a/docs/de/api.md
+++ b/docs/de/api.md
@@ -227,7 +227,7 @@ Ausführung über Docker:
 docker run --rm \
   -e GOOGLE_API_KEY=your_key \
   -e GITHUB_TOKEN=your_token \
-  ghcr.io/konstziv/ai-reviewbot:latest \
+  ghcr.io/konstziv/ai-code-reviewer:1 \
   --provider github \
   --repo owner/repo \
   --pr 123

--- a/docs/de/examples/gitlab-advanced.md
+++ b/docs/de/examples/gitlab-advanced.md
@@ -40,7 +40,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
 
   script:
     - ai-review
@@ -184,7 +184,7 @@ test:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/de/examples/gitlab-minimal.md
+++ b/docs/de/examples/gitlab-minimal.md
@@ -20,7 +20,7 @@ Die einfachste Konfiguration für GitLab CI.
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/de/gitlab.md
+++ b/docs/de/gitlab.md
@@ -94,7 +94,7 @@ only:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -107,7 +107,7 @@ ai-review:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -139,7 +139,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -166,8 +166,8 @@ Wenn Ihr GitLab keinen Zugriff auf `ghcr.io` hat, erstellen Sie einen Mirror:
 
 ```bash
 # Auf einer Maschine mit Zugriff
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 docker push gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 ```

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -77,7 +77,7 @@ Erstellen Sie in Ihrem Repository:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -165,7 +165,7 @@ graph TD
 === "Docker (empfohlen)"
 
     ```bash
-    docker pull ghcr.io/konstziv/ai-reviewbot:latest
+    docker pull ghcr.io/konstziv/ai-code-reviewer:1
     ```
 
 === "PyPI"

--- a/docs/de/installation.md
+++ b/docs/de/installation.md
@@ -51,7 +51,7 @@ Für GitLab verwenden Sie das Docker-Image in `.gitlab-ci.yml`:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -116,7 +116,7 @@ Keine Python-Installation erforderlich — alles ist im Container enthalten.
 **Schritt 1: Image herunterladen**
 
 ```bash
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 ```
 
 **Schritt 2: Review ausführen**
@@ -127,7 +127,7 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITHUB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --repo owner/repo --pr-number 123
     ```
 
@@ -137,15 +137,15 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITLAB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --provider gitlab --project owner/repo --mr-iid 123
     ```
 
 !!! tip "Docker-Images"
     Verfügbar von zwei Registries:
 
-    - `ghcr.io/konstziv/ai-reviewbot:latest` — GitHub Container Registry
-    - `konstziv/ai-reviewbot:latest` — DockerHub
+    - `ghcr.io/konstziv/ai-code-reviewer:1` — GitHub Container Registry
+    - `konstziv/ai-reviewbot:1` — DockerHub
 
 ---
 
@@ -233,10 +233,10 @@ Für Umgebungen mit eingeschränktem Internetzugang.
 
 ```bash
 # Image herunterladen
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 
 # In Datei speichern
-docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
+docker save ghcr.io/konstziv/ai-code-reviewer:1 > ai-code-reviewer.tar
 ```
 
 **Schritt 2: Datei in die geschlossene Umgebung übertragen**
@@ -248,7 +248,7 @@ docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
 docker load < ai-code-reviewer.tar
 
 # Für interne Registry neu taggen
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     registry.internal.company.com/devops/ai-code-reviewer:latest
 
 # Pushen

--- a/docs/de/quick-start.md
+++ b/docs/de/quick-start.md
@@ -74,7 +74,7 @@ Erstellen Sie im Stammverzeichnis Ihres Projekts die Datei `.gitlab-ci.yml`
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -227,7 +227,7 @@ Run via Docker:
 docker run --rm \
   -e GOOGLE_API_KEY=your_key \
   -e GITHUB_TOKEN=your_token \
-  ghcr.io/konstziv/ai-reviewbot:latest \
+  ghcr.io/konstziv/ai-code-reviewer:1 \
   --provider github \
   --repo owner/repo \
   --pr 123

--- a/docs/en/examples/gitlab-advanced.md
+++ b/docs/en/examples/gitlab-advanced.md
@@ -40,7 +40,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
 
   script:
     - ai-review
@@ -184,7 +184,7 @@ test:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/en/examples/gitlab-minimal.md
+++ b/docs/en/examples/gitlab-minimal.md
@@ -20,7 +20,7 @@ The simplest configuration for GitLab CI.
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/en/gitlab.md
+++ b/docs/en/gitlab.md
@@ -94,7 +94,7 @@ only:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -107,7 +107,7 @@ ai-review:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -139,7 +139,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -166,8 +166,8 @@ If your GitLab doesn't have access to `ghcr.io`, create a mirror:
 
 ```bash
 # On a machine with access
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 docker push gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 ```

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -77,7 +77,7 @@ In your repository, create:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -165,7 +165,7 @@ graph TD
 === "Docker (recommended)"
 
     ```bash
-    docker pull ghcr.io/konstziv/ai-reviewbot:latest
+    docker pull ghcr.io/konstziv/ai-code-reviewer:1
     ```
 
 === "PyPI"

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -51,7 +51,7 @@ For GitLab, use the Docker image in `.gitlab-ci.yml`:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -116,7 +116,7 @@ No Python installation required — everything is in the container.
 **Step 1: Pull the image**
 
 ```bash
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 ```
 
 **Step 2: Run the review**
@@ -127,7 +127,7 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITHUB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --repo owner/repo --pr-number 123
     ```
 
@@ -137,15 +137,15 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITLAB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --provider gitlab --project owner/repo --mr-iid 123
     ```
 
 !!! tip "Docker images"
     Available from two registries:
 
-    - `ghcr.io/konstziv/ai-reviewbot:latest` — GitHub Container Registry
-    - `konstziv/ai-reviewbot:latest` — DockerHub
+    - `ghcr.io/konstziv/ai-code-reviewer:1` — GitHub Container Registry
+    - `konstziv/ai-reviewbot:1` — DockerHub
 
 ---
 
@@ -233,10 +233,10 @@ For environments with limited internet access.
 
 ```bash
 # Pull the image
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 
 # Save to file
-docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
+docker save ghcr.io/konstziv/ai-code-reviewer:1 > ai-code-reviewer.tar
 ```
 
 **Step 2: Transfer the file to the closed environment**
@@ -248,7 +248,7 @@ docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
 docker load < ai-code-reviewer.tar
 
 # Re-tag for internal registry
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     registry.internal.company.com/devops/ai-code-reviewer:latest
 
 # Push

--- a/docs/en/quick-start.md
+++ b/docs/en/quick-start.md
@@ -74,7 +74,7 @@ In the root of your project, create file `.gitlab-ci.yml`
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review

--- a/docs/es/api.md
+++ b/docs/es/api.md
@@ -227,7 +227,7 @@ Ejecutar via Docker:
 docker run --rm \
   -e GOOGLE_API_KEY=your_key \
   -e GITHUB_TOKEN=your_token \
-  ghcr.io/konstziv/ai-reviewbot:latest \
+  ghcr.io/konstziv/ai-code-reviewer:1 \
   --provider github \
   --repo owner/repo \
   --pr 123

--- a/docs/es/examples/gitlab-advanced.md
+++ b/docs/es/examples/gitlab-advanced.md
@@ -40,7 +40,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
 
   script:
     - ai-review
@@ -184,7 +184,7 @@ test:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/es/examples/gitlab-minimal.md
+++ b/docs/es/examples/gitlab-minimal.md
@@ -20,7 +20,7 @@ La configuración más sencilla para GitLab CI.
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/es/gitlab.md
+++ b/docs/es/gitlab.md
@@ -94,7 +94,7 @@ only:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -107,7 +107,7 @@ ai-review:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -139,7 +139,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -166,8 +166,8 @@ Si tu GitLab no tiene acceso a `ghcr.io`, crea un mirror:
 
 ```bash
 # En una máquina con acceso
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 docker push gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 ```

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -77,7 +77,7 @@ En tu repositorio, crea:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -165,7 +165,7 @@ graph TD
 === "Docker (recomendado)"
 
     ```bash
-    docker pull ghcr.io/konstziv/ai-reviewbot:latest
+    docker pull ghcr.io/konstziv/ai-code-reviewer:1
     ```
 
 === "PyPI"

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -51,7 +51,7 @@ Para GitLab, usa la imagen Docker en `.gitlab-ci.yml`:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -116,7 +116,7 @@ No se requiere instalación de Python — todo está en el contenedor.
 **Paso 1: Descargar la imagen**
 
 ```bash
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 ```
 
 **Paso 2: Ejecutar la revisión**
@@ -127,7 +127,7 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITHUB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --repo owner/repo --pr-number 123
     ```
 
@@ -137,15 +137,15 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITLAB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --provider gitlab --project owner/repo --mr-iid 123
     ```
 
 !!! tip "Imágenes Docker"
     Disponibles en dos registros:
 
-    - `ghcr.io/konstziv/ai-reviewbot:latest` — GitHub Container Registry
-    - `konstziv/ai-reviewbot:latest` — DockerHub
+    - `ghcr.io/konstziv/ai-code-reviewer:1` — GitHub Container Registry
+    - `konstziv/ai-reviewbot:1` — DockerHub
 
 ---
 
@@ -233,10 +233,10 @@ Para entornos con acceso limitado a internet.
 
 ```bash
 # Descargar la imagen
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 
 # Guardar en archivo
-docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
+docker save ghcr.io/konstziv/ai-code-reviewer:1 > ai-code-reviewer.tar
 ```
 
 **Paso 2: Transferir el archivo al entorno cerrado**
@@ -248,7 +248,7 @@ docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
 docker load < ai-code-reviewer.tar
 
 # Re-etiquetar para el registro interno
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     registry.internal.company.com/devops/ai-code-reviewer:latest
 
 # Subir

--- a/docs/es/quick-start.md
+++ b/docs/es/quick-start.md
@@ -74,7 +74,7 @@ En la raíz de tu proyecto, crea el archivo `.gitlab-ci.yml`
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review

--- a/docs/it/api.md
+++ b/docs/it/api.md
@@ -227,7 +227,7 @@ Esegui via Docker:
 docker run --rm \
   -e GOOGLE_API_KEY=your_key \
   -e GITHUB_TOKEN=your_token \
-  ghcr.io/konstziv/ai-reviewbot:latest \
+  ghcr.io/konstziv/ai-code-reviewer:1 \
   --provider github \
   --repo owner/repo \
   --pr 123

--- a/docs/it/examples/gitlab-advanced.md
+++ b/docs/it/examples/gitlab-advanced.md
@@ -40,7 +40,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
 
   script:
     - ai-review
@@ -184,7 +184,7 @@ test:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/it/examples/gitlab-minimal.md
+++ b/docs/it/examples/gitlab-minimal.md
@@ -20,7 +20,7 @@ La configurazione piu semplice per GitLab CI.
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/it/gitlab.md
+++ b/docs/it/gitlab.md
@@ -94,7 +94,7 @@ only:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -107,7 +107,7 @@ ai-review:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -139,7 +139,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -166,8 +166,8 @@ Se il tuo GitLab non ha accesso a `ghcr.io`, crea un mirror:
 
 ```bash
 # Su una macchina con accesso
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 docker push gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 ```

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -77,7 +77,7 @@ Nel tuo repository, crea:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -165,7 +165,7 @@ graph TD
 === "Docker (consigliato)"
 
     ```bash
-    docker pull ghcr.io/konstziv/ai-reviewbot:latest
+    docker pull ghcr.io/konstziv/ai-code-reviewer:1
     ```
 
 === "PyPI"

--- a/docs/it/installation.md
+++ b/docs/it/installation.md
@@ -51,7 +51,7 @@ Per GitLab, usa l'immagine Docker in `.gitlab-ci.yml`:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -116,7 +116,7 @@ Non serve installare Python — tutto e nel container.
 **Passo 1: Scarica l'immagine**
 
 ```bash
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 ```
 
 **Passo 2: Esegui la revisione**
@@ -127,7 +127,7 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITHUB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --repo owner/repo --pr-number 123
     ```
 
@@ -137,15 +137,15 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITLAB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --provider gitlab --project owner/repo --mr-iid 123
     ```
 
 !!! tip "Immagini Docker"
     Disponibili da due registry:
 
-    - `ghcr.io/konstziv/ai-reviewbot:latest` — GitHub Container Registry
-    - `konstziv/ai-reviewbot:latest` — DockerHub
+    - `ghcr.io/konstziv/ai-code-reviewer:1` — GitHub Container Registry
+    - `konstziv/ai-reviewbot:1` — DockerHub
 
 ---
 
@@ -233,10 +233,10 @@ Per ambienti con accesso internet limitato.
 
 ```bash
 # Scarica l'immagine
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 
 # Salva su file
-docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
+docker save ghcr.io/konstziv/ai-code-reviewer:1 > ai-code-reviewer.tar
 ```
 
 **Passo 2: Trasferisci il file nell'ambiente chiuso**
@@ -248,7 +248,7 @@ docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
 docker load < ai-code-reviewer.tar
 
 # Re-tag per il registry interno
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     registry.internal.company.com/devops/ai-code-reviewer:latest
 
 # Push

--- a/docs/it/quick-start.md
+++ b/docs/it/quick-start.md
@@ -74,7 +74,7 @@ Nella root del tuo progetto, crea il file `.gitlab-ci.yml`
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review

--- a/docs/sr/api.md
+++ b/docs/sr/api.md
@@ -227,7 +227,7 @@ Pokretanje putem Docker-a:
 docker run --rm \
   -e GOOGLE_API_KEY=your_key \
   -e GITHUB_TOKEN=your_token \
-  ghcr.io/konstziv/ai-reviewbot:latest \
+  ghcr.io/konstziv/ai-code-reviewer:1 \
   --provider github \
   --repo owner/repo \
   --pr 123

--- a/docs/sr/examples/gitlab-advanced.md
+++ b/docs/sr/examples/gitlab-advanced.md
@@ -40,7 +40,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
 
   script:
     - ai-review
@@ -184,7 +184,7 @@ test:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/sr/examples/gitlab-minimal.md
+++ b/docs/sr/examples/gitlab-minimal.md
@@ -20,7 +20,7 @@ Najjednostavnija konfiguracija za GitLab CI.
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/sr/gitlab.md
+++ b/docs/sr/gitlab.md
@@ -94,7 +94,7 @@ only:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -107,7 +107,7 @@ ai-review:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -139,7 +139,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -166,8 +166,8 @@ Ako vaš GitLab nema pristup `ghcr.io`, kreirajte mirror:
 
 ```bash
 # Na mašini sa pristupom
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 docker push gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 ```

--- a/docs/sr/index.md
+++ b/docs/sr/index.md
@@ -77,7 +77,7 @@ U vašem repozitorijumu kreirajte:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -165,7 +165,7 @@ graph TD
 === "Docker (preporučeno)"
 
     ```bash
-    docker pull ghcr.io/konstziv/ai-reviewbot:latest
+    docker pull ghcr.io/konstziv/ai-code-reviewer:1
     ```
 
 === "PyPI"

--- a/docs/sr/installation.md
+++ b/docs/sr/installation.md
@@ -51,7 +51,7 @@ Za GitLab, koristite Docker image u `.gitlab-ci.yml`:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -116,7 +116,7 @@ Nije potrebna instalacija Python-a — sve je u kontejneru.
 **Korak 1: Preuzmite image**
 
 ```bash
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 ```
 
 **Korak 2: Pokrenite reviziju**
@@ -127,7 +127,7 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITHUB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --repo owner/repo --pr-number 123
     ```
 
@@ -137,15 +137,15 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITLAB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --provider gitlab --project owner/repo --mr-iid 123
     ```
 
 !!! tip "Docker images"
     Dostupni iz dva registra:
 
-    - `ghcr.io/konstziv/ai-reviewbot:latest` — GitHub Container Registry
-    - `konstziv/ai-reviewbot:latest` — DockerHub
+    - `ghcr.io/konstziv/ai-code-reviewer:1` — GitHub Container Registry
+    - `konstziv/ai-reviewbot:1` — DockerHub
 
 ---
 
@@ -233,10 +233,10 @@ Za okruženja sa ograničenim pristupom internetu.
 
 ```bash
 # Preuzmite image
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 
 # Sačuvajte u fajl
-docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
+docker save ghcr.io/konstziv/ai-code-reviewer:1 > ai-code-reviewer.tar
 ```
 
 **Korak 2: Prenesite fajl u zatvoreno okruženje**
@@ -248,7 +248,7 @@ docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
 docker load < ai-code-reviewer.tar
 
 # Ponovo tagirajte za interni registar
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     registry.internal.company.com/devops/ai-code-reviewer:latest
 
 # Push

--- a/docs/sr/quick-start.md
+++ b/docs/sr/quick-start.md
@@ -74,7 +74,7 @@ U korijenu vašeg projekta, kreirajte fajl `.gitlab-ci.yml`
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review

--- a/docs/uk/api.md
+++ b/docs/uk/api.md
@@ -227,7 +227,7 @@ Please specify --provider, --repo, and --pr manually.
 docker run --rm \
   -e GOOGLE_API_KEY=your_key \
   -e GITHUB_TOKEN=your_token \
-  ghcr.io/konstziv/ai-reviewbot:latest \
+  ghcr.io/konstziv/ai-code-reviewer:1 \
   --provider github \
   --repo owner/repo \
   --pr 123

--- a/docs/uk/examples/gitlab-advanced.md
+++ b/docs/uk/examples/gitlab-advanced.md
@@ -40,7 +40,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
 
   script:
     - ai-review
@@ -184,7 +184,7 @@ test:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/uk/examples/gitlab-minimal.md
+++ b/docs/uk/examples/gitlab-minimal.md
@@ -20,7 +20,7 @@
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:

--- a/docs/uk/gitlab.md
+++ b/docs/uk/gitlab.md
@@ -94,7 +94,7 @@ only:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -107,7 +107,7 @@ ai-review:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -139,7 +139,7 @@ stages:
 
 ai-review:
   stage: review
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -166,8 +166,8 @@ variables:
 
 ```bash
 # На машині з доступом
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 docker push gitlab.mycompany.com:5050/devops/ai-code-reviewer:latest
 ```

--- a/docs/uk/index.md
+++ b/docs/uk/index.md
@@ -77,7 +77,7 @@ jobs:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   script:
     - ai-review
   rules:
@@ -165,7 +165,7 @@ graph TD
 === "Docker (рекомендовано)"
 
     ```bash
-    docker pull ghcr.io/konstziv/ai-reviewbot:latest
+    docker pull ghcr.io/konstziv/ai-code-reviewer:1
     ```
 
 === "PyPI"

--- a/docs/uk/installation.md
+++ b/docs/uk/installation.md
@@ -51,7 +51,7 @@ jobs:
 ```yaml
 # .gitlab-ci.yml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review
@@ -116,7 +116,7 @@ ai-review:
 **Крок 1: Завантажте image**
 
 ```bash
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 ```
 
 **Крок 2: Запустіть review**
@@ -127,7 +127,7 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITHUB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --repo owner/repo --pr-number 123
     ```
 
@@ -137,15 +137,15 @@ docker pull ghcr.io/konstziv/ai-reviewbot:latest
     docker run --rm \
       -e GOOGLE_API_KEY=your_api_key \
       -e GITLAB_TOKEN=your_token \
-      ghcr.io/konstziv/ai-reviewbot:latest \
+      ghcr.io/konstziv/ai-code-reviewer:1 \
       --provider gitlab --project owner/repo --mr-iid 123
     ```
 
 !!! tip "Docker images"
     Доступні з двох реєстрів:
 
-    - `ghcr.io/konstziv/ai-reviewbot:latest` — GitHub Container Registry
-    - `konstziv/ai-reviewbot:latest` — DockerHub
+    - `ghcr.io/konstziv/ai-code-reviewer:1` — GitHub Container Registry
+    - `konstziv/ai-reviewbot:1` — DockerHub
 
 ---
 
@@ -233,10 +233,10 @@ export GITHUB_TOKEN=your_token  # або GITLAB_TOKEN для GitLab
 
 ```bash
 # Завантажити image
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 
 # Зберегти в файл
-docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
+docker save ghcr.io/konstziv/ai-code-reviewer:1 > ai-code-reviewer.tar
 ```
 
 **Крок 2: Перенести файл у закрите середовище**
@@ -248,7 +248,7 @@ docker save ghcr.io/konstziv/ai-reviewbot:latest > ai-code-reviewer.tar
 docker load < ai-code-reviewer.tar
 
 # Перетегувати для internal registry
-docker tag ghcr.io/konstziv/ai-reviewbot:latest \
+docker tag ghcr.io/konstziv/ai-code-reviewer:1 \
     registry.internal.company.com/devops/ai-code-reviewer:latest
 
 # Опублікувати

--- a/docs/uk/quick-start.md
+++ b/docs/uk/quick-start.md
@@ -76,7 +76,7 @@ jobs:
 
 ```yaml
 ai-review:
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
   stage: test
   script:
     - ai-review

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@ You can also run the reviewer directly with Docker:
 
 ```bash
 # Pull the image
-docker pull ghcr.io/konstziv/ai-reviewbot:latest
+docker pull ghcr.io/konstziv/ai-code-reviewer:1
 
 # Run with environment variables
 docker run --rm \
@@ -45,7 +45,7 @@ docker run --rm \
   -e GOOGLE_API_KEY="xxx" \
   -e GITHUB_REPOSITORY="owner/repo" \
   -e GITHUB_REF="refs/pull/123/merge" \
-  ghcr.io/konstziv/ai-reviewbot:latest
+  ghcr.io/konstziv/ai-code-reviewer:1
 ```
 
 ## Supported Platforms

--- a/examples/gitlab-ci.yml
+++ b/examples/gitlab-ci.yml
@@ -17,7 +17,7 @@
 # AI Code Review job
 ai-review:
   stage: test
-  image: ghcr.io/konstziv/ai-reviewbot:latest
+  image: ghcr.io/konstziv/ai-code-reviewer:1
 
   # Only run on merge requests
   rules:
@@ -55,7 +55,7 @@ ai-review:
 #
 # ai-review:
 #   stage: test
-#   image: ghcr.io/konstziv/ai-reviewbot:latest
+#   image: ghcr.io/konstziv/ai-code-reviewer:1
 #   rules:
 #     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
 #   variables:


### PR DESCRIPTION
- Fix GHCR URL: ai-reviewbot → ai-code-reviewer (matches repo name)
- Replace :latest with :1 (latest not published for alpha)
- Fix README.md Example Output formatting (blockquote instead of nested code blocks)
- Update DOCKERHUB_README.md tag descriptions

Affected: 46 files across docs/{uk,en,de,es,sr,it}/, examples/, README.md

