### PR TITLE
chore: move unused deps to optional, fix GitLab N+1 diffs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,41 +18,38 @@ classifiers = [
 ]
 
 dependencies = [
-    # LLM Orchestration
-    "langchain>=1.2.6",
-    "langgraph>=1.0.6",
-    # LLM Providers
-    "langchain-anthropic>=1.3.1",         # Claude
-    "langchain-openai>=1.1.7",            # GPT
-    "langchain-google-genai>=4.2.0",      # Gemini
-    "langchain-deepseek>=1.0.1",          # DeepSeek
-    "langchain-ollama>=1.0.1",            # Ollama (local)
-    "anthropic>=0.76.0",                  # Direct Anthropic SDK
-    "openai>=2.15.0",                     # Direct OpenAI SDK
-    "google-genai>=1.59.0",                # New Google GenAI SDK
+    # LLM
+    "google-genai>=1.59.0",
+    "google-api-core>=2.29.0",
     # Core
     "pydantic>=2.12.5",
     "pydantic-settings>=2.12.0",
-    "click>=8.3.1",
     # Resilience
     "tenacity>=9.0.0",
     # HTTP & APIs
     "httpx>=0.28.1",
     "python-gitlab>=7.1.0",
     "PyGithub>=2.8.1",
-    # Git operations
-    "GitPython>=3.1.46",
-    # Config & Environment
-    "python-dotenv>=1.2.1",
+    # Config
     "pyyaml>=6.0.3",
     # Language validation
     "python-iso639>=0.0.10",
     # CLI & Output
     "rich>=14.2.0",
     "typer>=0.21.1",
-    # Async
-    "aiofiles>=25.1.0",
-    "google-api-core>=2.29.0",
+]
+
+[project.optional-dependencies]
+all-providers = [
+    "langchain>=1.2.6",
+    "langgraph>=1.0.6",
+    "langchain-anthropic>=1.3.1",
+    "langchain-openai>=1.1.7",
+    "langchain-google-genai>=4.2.0",
+    "langchain-deepseek>=1.0.1",
+    "langchain-ollama>=1.0.1",
+    "anthropic>=0.76.0",
+    "openai>=2.15.0",
 ]
 
 [project.scripts]

--- a/src/ai_reviewer/integrations/gitlab.py
+++ b/src/ai_reviewer/integrations/gitlab.py
@@ -218,38 +218,37 @@ class GitLabClient(GitProvider, RepositoryProvider, ConversationProvider):
             notes = discussion.attributes.get("notes", [])
             comments.extend(_parse_discussion_notes(notes, discussion_id))
 
-        # Fetch file changes
+        # Fetch file changes (single API call instead of N+1)
         changes: list[FileChange] = []
-        for diff in mr.diffs.list(iterator=True):
-            diff_detail = mr.diffs.get(diff.id)
-            for file_diff in diff_detail.diffs:
-                # Determine change type
-                if file_diff.get("new_file"):
-                    change_type = FileChangeType.ADDED
-                elif file_diff.get("deleted_file"):
-                    change_type = FileChangeType.DELETED
-                elif file_diff.get("renamed_file"):
-                    change_type = FileChangeType.RENAMED
-                else:
-                    change_type = FileChangeType.MODIFIED
+        mr_changes = mr.changes()
+        for file_diff in mr_changes.get("changes", []):  # type: ignore[union-attr]
+            # Determine change type
+            if file_diff.get("new_file"):
+                change_type = FileChangeType.ADDED
+            elif file_diff.get("deleted_file"):
+                change_type = FileChangeType.DELETED
+            elif file_diff.get("renamed_file"):
+                change_type = FileChangeType.RENAMED
+            else:
+                change_type = FileChangeType.MODIFIED
 
-                # Count additions/deletions from diff
-                diff_content = file_diff.get("diff", "")
-                additions = sum(1 for line in diff_content.split("\n") if line.startswith("+"))
-                deletions = sum(1 for line in diff_content.split("\n") if line.startswith("-"))
+            # Count additions/deletions from diff
+            diff_content = file_diff.get("diff", "")
+            additions = sum(1 for line in diff_content.split("\n") if line.startswith("+"))
+            deletions = sum(1 for line in diff_content.split("\n") if line.startswith("-"))
 
-                changes.append(
-                    FileChange(
-                        filename=file_diff.get("new_path", file_diff.get("old_path", "")),
-                        change_type=change_type,
-                        additions=additions,
-                        deletions=deletions,
-                        patch=diff_content if diff_content else None,
-                        previous_filename=file_diff.get("old_path")
-                        if file_diff.get("renamed_file")
-                        else None,
-                    )
+            changes.append(
+                FileChange(
+                    filename=file_diff.get("new_path", file_diff.get("old_path", "")),
+                    change_type=change_type,
+                    additions=additions,
+                    deletions=deletions,
+                    patch=diff_content if diff_content else None,
+                    previous_filename=file_diff.get("old_path")
+                    if file_diff.get("renamed_file")
+                    else None,
                 )
+            )
 
         return MergeRequest(
             number=mr.iid,

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -106,23 +106,19 @@ class TestGitLabClient:
         )
         mock_mr.discussions.list.return_value = [discussion]
 
-        # Mock Diffs
-        mock_diff = Mock()
-        mock_diff.id = 1
-        mock_mr.diffs.list.return_value = [mock_diff]
-
-        mock_diff_detail = Mock()
-        mock_diff_detail.diffs = [
-            {
-                "new_file": False,
-                "deleted_file": False,
-                "renamed_file": False,
-                "new_path": "test.py",
-                "old_path": "test.py",
-                "diff": "@@ -1,1 +1,2 @@\n-old\n+new\n+added",
-            }
-        ]
-        mock_mr.diffs.get.return_value = mock_diff_detail
+        # Mock changes (single API call instead of N+1 diffs)
+        mock_mr.changes.return_value = {
+            "changes": [
+                {
+                    "new_file": False,
+                    "deleted_file": False,
+                    "renamed_file": False,
+                    "new_path": "test.py",
+                    "old_path": "test.py",
+                    "diff": "@@ -1,1 +1,2 @@\n-old\n+new\n+added",
+                }
+            ]
+        }
 
         # Execute
         mr = client.get_merge_request("owner/repo", 1)
@@ -157,7 +153,7 @@ class TestGitLabClient:
         mock_mr.web_url = "url"
         mock_mr.created_at = "2024-01-01T00:00:00Z"
         mock_mr.updated_at = "2024-01-01T00:00:00Z"
-        mock_mr.diffs.list.return_value = []
+        mock_mr.changes.return_value = {"changes": []}
 
         # Mock discussion with bot note
         discussion = _make_discussion(
@@ -200,7 +196,7 @@ class TestGitLabClient:
         mock_mr.web_url = "url"
         mock_mr.created_at = "2024-01-01T00:00:00Z"
         mock_mr.updated_at = "2024-01-01T00:00:00Z"
-        mock_mr.diffs.list.return_value = []
+        mock_mr.changes.return_value = {"changes": []}
 
         # Mock discussion with system note
         discussion = _make_discussion(
@@ -239,7 +235,7 @@ class TestGitLabClient:
         mock_mr.web_url = "url"
         mock_mr.created_at = "2024-01-01T00:00:00Z"
         mock_mr.updated_at = "2024-01-01T00:00:00Z"
-        mock_mr.diffs.list.return_value = []
+        mock_mr.changes.return_value = {"changes": []}
 
         # Discussion with note that has no position key
         discussion = _make_discussion(
@@ -278,7 +274,7 @@ class TestGitLabClient:
         mock_mr.web_url = "url"
         mock_mr.created_at = "2024-01-01T00:00:00Z"
         mock_mr.updated_at = "2024-01-01T00:00:00Z"
-        mock_mr.diffs.list.return_value = []
+        mock_mr.changes.return_value = {"changes": []}
 
         # Discussion with 2 notes (root + reply)
         discussion = _make_discussion(

--- a/uv.lock
+++ b/uv.lock
@@ -11,13 +11,23 @@ name = "ai-reviewbot"
 version = "1.0.0a8"
 source = { editable = "." }
 dependencies = [
-    { name = "aiofiles" },
-    { name = "anthropic" },
-    { name = "click" },
-    { name = "gitpython" },
     { name = "google-api-core" },
     { name = "google-genai" },
     { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pygithub" },
+    { name = "python-gitlab" },
+    { name = "python-iso639" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "tenacity" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+all-providers = [
+    { name = "anthropic" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-deepseek" },
@@ -26,16 +36,6 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "langgraph" },
     { name = "openai" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pygithub" },
-    { name = "python-dotenv" },
-    { name = "python-gitlab" },
-    { name = "python-iso639" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "tenacity" },
-    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -63,25 +63,21 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = ">=25.1.0" },
-    { name = "anthropic", specifier = ">=0.76.0" },
-    { name = "click", specifier = ">=8.3.1" },
-    { name = "gitpython", specifier = ">=3.1.46" },
+    { name = "anthropic", marker = "extra == 'all-providers'", specifier = ">=0.76.0" },
     { name = "google-api-core", specifier = ">=2.29.0" },
     { name = "google-genai", specifier = ">=1.59.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "langchain", specifier = ">=1.2.6" },
-    { name = "langchain-anthropic", specifier = ">=1.3.1" },
-    { name = "langchain-deepseek", specifier = ">=1.0.1" },
-    { name = "langchain-google-genai", specifier = ">=4.2.0" },
-    { name = "langchain-ollama", specifier = ">=1.0.1" },
-    { name = "langchain-openai", specifier = ">=1.1.7" },
-    { name = "langgraph", specifier = ">=1.0.6" },
-    { name = "openai", specifier = ">=2.15.0" },
+    { name = "langchain", marker = "extra == 'all-providers'", specifier = ">=1.2.6" },
+    { name = "langchain-anthropic", marker = "extra == 'all-providers'", specifier = ">=1.3.1" },
+    { name = "langchain-deepseek", marker = "extra == 'all-providers'", specifier = ">=1.0.1" },
+    { name = "langchain-google-genai", marker = "extra == 'all-providers'", specifier = ">=4.2.0" },
+    { name = "langchain-ollama", marker = "extra == 'all-providers'", specifier = ">=1.0.1" },
+    { name = "langchain-openai", marker = "extra == 'all-providers'", specifier = ">=1.1.7" },
+    { name = "langgraph", marker = "extra == 'all-providers'", specifier = ">=1.0.6" },
+    { name = "openai", marker = "extra == 'all-providers'", specifier = ">=2.15.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "pygithub", specifier = ">=2.8.1" },
-    { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-gitlab", specifier = ">=7.1.0" },
     { name = "python-iso639", specifier = ">=0.0.10" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -89,6 +85,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "typer", specifier = ">=0.21.1" },
 ]
+provides-extras = ["all-providers"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -111,15 +108,6 @@ docs = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.7.1" },
     { name = "mkdocs-static-i18n", specifier = ">=1.3.0" },
-]
-
-[[package]]
-name = "aiofiles"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
 ]
 
 [[package]]
@@ -509,30 +497,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
-]
-
-[[package]]
-name = "gitdb"
-version = "4.0.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "smmap" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
-]
-
-[[package]]
-name = "gitpython"
-version = "3.1.46"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "gitdb" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
 ]
 
 [[package]]
@@ -2066,15 +2030,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "smmap"
-version = "5.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Коміт 677cd4a на гілці 80-task-14-housekeeping:                                                                
                                                                                   
  - 9 неиспользуемых залежностей перенесено до [project.optional-dependencies]                                           
  - GitLab N+1 (diffs.list() + diffs.get()) замінено на один виклик mr.changes()
  - Тести оновлені                                                                                                       
  - Всі перевірки пройшли: ruff ✓, mypy ✓, 556 тестів ✓  


- Move 9 unused deps (langchain, anthropic, openai, etc.) to optional-dependencies [all-providers] group
- Replace GitLab diffs.list() + diffs.get() N+1 pattern with single mr.changes() API call
- Update integration tests to use mr.changes() mock
