### PR TITLE
feat: add Discovery LLM prompts for Layer 3 interpretation (task 2.5)

### DIFF
--- a/src/ai_reviewer/discovery/__init__.py
+++ b/src/ai_reviewer/discovery/__init__.py
@@ -22,21 +22,29 @@ from ai_reviewer.discovery.models import (
     ReviewGuidance,
     ToolCategory,
 )
+from ai_reviewer.discovery.prompts import (
+    DISCOVERY_SYSTEM_PROMPT,
+    LLMDiscoveryResponse,
+    build_interpretation_prompt,
+)
 from ai_reviewer.discovery.reviewbot_config import (
     generate_reviewbot_md,
     parse_reviewbot_md,
 )
 
 __all__ = [
+    "DISCOVERY_SYSTEM_PROMPT",
     "AutomatedChecks",
     "CIInsights",
     "ConfigContent",
     "DetectedTool",
     "Gap",
+    "LLMDiscoveryResponse",
     "PlatformData",
     "ProjectProfile",
     "ReviewGuidance",
     "ToolCategory",
+    "build_interpretation_prompt",
     "generate_reviewbot_md",
     "parse_reviewbot_md",
 ]

--- a/src/ai_reviewer/discovery/prompts.py
+++ b/src/ai_reviewer/discovery/prompts.py
@@ -1,0 +1,140 @@
+"""LLM prompts for Discovery Layer 3 (interpretation).
+
+Used **only** when deterministic layers (platform API, CI, configs) leave
+gaps. The LLM receives a compact summary of what was already collected
+and fills in framework detection, review guidance, and conventions.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from ai_reviewer.discovery.models import Gap  # noqa: TC001
+
+if TYPE_CHECKING:
+    from ai_reviewer.discovery.config_collector import ConfigContent
+    from ai_reviewer.discovery.models import CIInsights, PlatformData
+
+# ── Response model ───────────────────────────────────────────────────
+
+
+class LLMDiscoveryResponse(BaseModel):
+    """Structured response from the LLM interpretation step.
+
+    Contains only fields that cannot be extracted deterministically
+    from CI configuration or config files.
+
+    Attributes:
+        framework: Detected framework (e.g. ``Django``, ``FastAPI``, ``React``).
+        architecture_notes: Brief notes on project architecture.
+        skip_in_review: Areas a reviewer should skip (already automated).
+        focus_in_review: Areas a reviewer should focus on (gaps in automation).
+        conventions: Project-specific conventions detected from configs.
+        gaps: Unresolved questions the LLM could not answer.
+    """
+
+    framework: str | None = Field(default=None, description="Detected framework")
+    architecture_notes: str | None = Field(default=None, description="Brief architecture notes")
+    skip_in_review: list[str] = Field(
+        default_factory=list, description="Areas to skip (already automated)"
+    )
+    focus_in_review: list[str] = Field(default_factory=list, description="Areas to focus on (gaps)")
+    conventions: list[str] = Field(default_factory=list, description="Project conventions")
+    gaps: list[Gap] = Field(default_factory=list, description="Unresolved questions")
+
+
+# ── System prompt ────────────────────────────────────────────────────
+
+DISCOVERY_SYSTEM_PROMPT = """\
+You are a project setup analyst.
+Your task: interpret project configuration files and determine \
+what a code reviewer should know about this project.
+
+Rules:
+- Be concise and specific.
+- Only list what you can CONFIRM from the provided data.
+- If uncertain, add a Gap with a question for the developer.
+- Do NOT guess or hallucinate tools/frameworks.
+- Return valid JSON matching the provided schema.\
+"""
+
+
+# ── Prompt builder ───────────────────────────────────────────────────
+
+
+def build_interpretation_prompt(
+    platform_data: PlatformData,
+    ci_insights: CIInsights | None,
+    configs: tuple[ConfigContent, ...],
+) -> str:
+    """Build a compact user prompt for LLM interpretation.
+
+    Assembles platform data, CI insights, and config file contents
+    into a structured Markdown prompt for the LLM.
+
+    Args:
+        platform_data: Repository metadata from platform API.
+        ci_insights: Parsed CI configuration, if available.
+        configs: Collected configuration file contents.
+
+    Returns:
+        Formatted prompt string.
+    """
+    parts: list[str] = ["# Project Setup Analysis\n"]
+
+    # Languages & metadata
+    parts.append(f"## Languages: {platform_data.primary_language}")
+    if platform_data.languages:
+        lang_list = ", ".join(
+            f"{lang} ({pct:.0f}%)" for lang, pct in platform_data.languages.items()
+        )
+        parts.append(f"Distribution: {lang_list}")
+    if platform_data.topics:
+        parts.append(f"Topics: {', '.join(platform_data.topics)}")
+    if platform_data.description:
+        parts.append(f"Description: {platform_data.description}")
+
+    # CI insights
+    if ci_insights:
+        tools = [t.name for t in ci_insights.detected_tools]
+        parts.append(f"\n## CI Tools: {', '.join(tools) or 'none detected'}")
+        if ci_insights.python_version:
+            parts.append(f"Python: {ci_insights.python_version}")
+        if ci_insights.node_version:
+            parts.append(f"Node: {ci_insights.node_version}")
+        if ci_insights.go_version:
+            parts.append(f"Go: {ci_insights.go_version}")
+        if ci_insights.package_manager:
+            parts.append(f"Package manager: {ci_insights.package_manager}")
+        if ci_insights.services:
+            parts.append(f"Services: {', '.join(ci_insights.services)}")
+        if ci_insights.min_coverage is not None:
+            parts.append(f"Min coverage: {ci_insights.min_coverage}%")
+
+    # Config files
+    if configs:
+        parts.append("\n## Config Files")
+        for cfg in configs:
+            truncation_note = " (truncated)" if cfg.truncated else ""
+            parts.append(f"\n### {cfg.path}{truncation_note}")
+            parts.append(f"```\n{cfg.content}\n```")
+
+    # Task
+    parts.append("\n## Task")
+    parts.append("Based on the above, determine:")
+    parts.append("1. Framework (if detectable from dependencies or config)")
+    parts.append("2. What a reviewer should SKIP (already automated by CI)")
+    parts.append("3. What a reviewer should FOCUS on (gaps in automation)")
+    parts.append("4. Project conventions (from config files)")
+    parts.append("5. Questions if anything is unclear (as Gaps)")
+
+    return "\n".join(parts)
+
+
+__all__ = [
+    "DISCOVERY_SYSTEM_PROMPT",
+    "LLMDiscoveryResponse",
+    "build_interpretation_prompt",
+]

--- a/tests/unit/test_discovery/test_prompts.py
+++ b/tests/unit/test_discovery/test_prompts.py
@@ -1,0 +1,235 @@
+"""Tests for discovery.prompts — LLM interpretation prompts."""
+
+from __future__ import annotations
+
+from ai_reviewer.discovery.config_collector import ConfigContent
+from ai_reviewer.discovery.models import (
+    CIInsights,
+    DetectedTool,
+    Gap,
+    PlatformData,
+    ToolCategory,
+)
+from ai_reviewer.discovery.prompts import (
+    DISCOVERY_SYSTEM_PROMPT,
+    LLMDiscoveryResponse,
+    build_interpretation_prompt,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_platform_data(
+    *,
+    languages: dict[str, float] | None = None,
+    topics: tuple[str, ...] = (),
+    description: str | None = None,
+) -> PlatformData:
+    return PlatformData(
+        languages=languages or {"Python": 85.0, "Shell": 15.0},
+        primary_language="Python",
+        topics=topics,
+        description=description,
+    )
+
+
+def _make_ci_insights(
+    *,
+    tools: tuple[DetectedTool, ...] = (),
+    python_version: str | None = "3.13",
+    package_manager: str | None = "uv",
+    services: tuple[str, ...] = (),
+    min_coverage: int | None = None,
+) -> CIInsights:
+    return CIInsights(
+        ci_file_path=".github/workflows/ci.yml",
+        detected_tools=tools,
+        python_version=python_version,
+        package_manager=package_manager,
+        services=services,
+        min_coverage=min_coverage,
+    )
+
+
+def _make_config(
+    path: str = "pyproject.toml",
+    content: str = "[tool.ruff]\nline-length = 88\n",
+    *,
+    truncated: bool = False,
+) -> ConfigContent:
+    return ConfigContent(
+        path=path,
+        content=content,
+        size_chars=len(content),
+        truncated=truncated,
+    )
+
+
+# ── TestLLMDiscoveryResponse ─────────────────────────────────────────
+
+
+class TestLLMDiscoveryResponse:
+    """Tests for the LLM response model."""
+
+    def test_defaults(self) -> None:
+        resp = LLMDiscoveryResponse()
+        assert resp.framework is None
+        assert resp.architecture_notes is None
+        assert resp.skip_in_review == []
+        assert resp.focus_in_review == []
+        assert resp.conventions == []
+        assert resp.gaps == []
+
+    def test_full_response(self) -> None:
+        resp = LLMDiscoveryResponse(
+            framework="Django 5.1",
+            architecture_notes="Monolith with REST API",
+            skip_in_review=["formatting", "type errors"],
+            focus_in_review=["security", "SQL queries"],
+            conventions=["Google docstrings"],
+            gaps=[Gap(observation="No SAST", default_assumption="No security scanning")],
+        )
+        assert resp.framework == "Django 5.1"
+        assert len(resp.skip_in_review) == 2
+        assert len(resp.gaps) == 1
+        assert resp.gaps[0].observation == "No SAST"
+
+    def test_json_roundtrip(self) -> None:
+        resp = LLMDiscoveryResponse(
+            framework="FastAPI",
+            skip_in_review=["formatting"],
+            conventions=["Conventional commits"],
+        )
+        data = resp.model_dump_json()
+        parsed = LLMDiscoveryResponse.model_validate_json(data)
+        assert parsed == resp
+
+
+# ── TestDiscoverySystemPrompt ────────────────────────────────────────
+
+
+class TestDiscoverySystemPrompt:
+    """Tests for the system prompt constant."""
+
+    def test_is_nonempty_string(self) -> None:
+        assert isinstance(DISCOVERY_SYSTEM_PROMPT, str)
+        assert len(DISCOVERY_SYSTEM_PROMPT) > 50
+
+    def test_contains_key_instructions(self) -> None:
+        assert "concise" in DISCOVERY_SYSTEM_PROMPT.lower()
+        assert "confirm" in DISCOVERY_SYSTEM_PROMPT.lower()
+        assert "json" in DISCOVERY_SYSTEM_PROMPT.lower()
+
+
+# ── TestBuildInterpretationPrompt ────────────────────────────────────
+
+
+class TestBuildInterpretationPrompt:
+    """Tests for build_interpretation_prompt."""
+
+    def test_minimal_prompt(self) -> None:
+        pd = _make_platform_data()
+        result = build_interpretation_prompt(pd, None, ())
+        assert "# Project Setup Analysis" in result
+        assert "Python" in result
+        assert "## CI Tools" not in result
+        assert "## Config Files" not in result
+
+    def test_includes_language_distribution(self) -> None:
+        pd = _make_platform_data(languages={"Python": 85.0, "Shell": 15.0})
+        result = build_interpretation_prompt(pd, None, ())
+        assert "Python (85%)" in result
+        assert "Shell (15%)" in result
+
+    def test_includes_topics(self) -> None:
+        pd = _make_platform_data(topics=("code-review", "ai", "python"))
+        result = build_interpretation_prompt(pd, None, ())
+        assert "code-review" in result
+        assert "ai" in result
+
+    def test_includes_description(self) -> None:
+        pd = _make_platform_data(description="AI code review bot")
+        result = build_interpretation_prompt(pd, None, ())
+        assert "AI code review bot" in result
+
+    def test_includes_ci_insights(self) -> None:
+        pd = _make_platform_data()
+        ci = _make_ci_insights(
+            tools=(
+                DetectedTool(name="ruff", category=ToolCategory.LINTING),
+                DetectedTool(name="mypy", category=ToolCategory.TYPE_CHECKING),
+            ),
+            services=("postgres", "redis"),
+            min_coverage=80,
+        )
+        result = build_interpretation_prompt(pd, ci, ())
+        assert "ruff" in result
+        assert "mypy" in result
+        assert "Python: 3.13" in result
+        assert "uv" in result
+        assert "postgres" in result
+        assert "80%" in result
+
+    def test_includes_node_and_go_versions(self) -> None:
+        pd = _make_platform_data()
+        ci = CIInsights(
+            ci_file_path=".github/workflows/ci.yml",
+            node_version="22.x",
+            go_version="1.22",
+            python_version=None,
+            package_manager=None,
+        )
+        result = build_interpretation_prompt(pd, ci, ())
+        assert "Node: 22.x" in result
+        assert "Go: 1.22" in result
+
+    def test_includes_config_files(self) -> None:
+        pd = _make_platform_data()
+        configs = (
+            _make_config("pyproject.toml", "[tool.ruff]\nline-length = 88"),
+            _make_config("tsconfig.json", '{"strict": true}'),
+        )
+        result = build_interpretation_prompt(pd, None, configs)
+        assert "### pyproject.toml" in result
+        assert "line-length = 88" in result
+        assert "### tsconfig.json" in result
+
+    def test_truncated_config_noted(self) -> None:
+        pd = _make_platform_data()
+        configs = (_make_config("big.toml", "x" * 100, truncated=True),)
+        result = build_interpretation_prompt(pd, None, configs)
+        assert "(truncated)" in result
+
+    def test_includes_task_section(self) -> None:
+        pd = _make_platform_data()
+        result = build_interpretation_prompt(pd, None, ())
+        assert "## Task" in result
+        assert "Framework" in result
+        assert "SKIP" in result
+        assert "FOCUS" in result
+        assert "conventions" in result.lower()
+
+    def test_full_prompt_under_token_estimate(self) -> None:
+        """Full prompt with typical data should stay compact."""
+        pd = _make_platform_data(
+            topics=("python", "code-review"),
+            description="AI reviewer",
+        )
+        ci = _make_ci_insights(
+            tools=(
+                DetectedTool(name="ruff", category=ToolCategory.LINTING),
+                DetectedTool(name="mypy", category=ToolCategory.TYPE_CHECKING),
+                DetectedTool(name="pytest", category=ToolCategory.TESTING),
+            ),
+            min_coverage=80,
+        )
+        configs = (_make_config("pyproject.toml", "[tool.ruff]\nline-length = 88\n" * 5),)
+        result = build_interpretation_prompt(pd, ci, configs)
+        # Rough estimate: 1 token ~ 4 chars; should be well under 2000 tokens
+        assert len(result) < 8000
+
+    def test_no_ci_tools_says_none(self) -> None:
+        pd = _make_platform_data()
+        ci = _make_ci_insights(tools=())
+        result = build_interpretation_prompt(pd, ci, ())
+        assert "none detected" in result


### PR DESCRIPTION
Що зроблено (Task 2.5):                                                                                               
   

  │                   Файл                    │                                Зміни                                 │
  
  │ src/ai_reviewer/discovery/prompts.py      │ Новий — LLMDiscoveryResponse, DISCOVERY_SYSTEM_PROMPT,               │
  │                                           │ build_interpretation_prompt()                                        │
  │ src/ai_reviewer/discovery/__init__.py     │ Re-export 3 нових символів                                           │

  │ tests/unit/test_discovery/test_prompts.py │ Новий — 16 тестів                                                    │


LLMDiscoveryResponse model for structured LLM output (framework, guidance, conventions, gaps). DISCOVERY_SYSTEM_PROMPT with strict rules (confirm-only, no hallucination). build_interpretation_prompt() assembles platform data, CI insights, and config contents into compact Markdown.

16 tests covering response model, system prompt, prompt builder with all branches (languages, topics, CI tools, versions, configs, truncation).

