### PR TITLE
feat: inject ProjectProfile into review prompt (task 3.1)

### DIFF
--- a/src/ai_reviewer/core/models.py
+++ b/src/ai_reviewer/core/models.py
@@ -11,8 +11,12 @@ from __future__ import annotations
 
 from datetime import datetime  # noqa: TC003 - required at runtime for Pydantic
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+if TYPE_CHECKING:
+    from ai_reviewer.discovery.models import ProjectProfile
 
 
 def _validate_timezone_aware(v: datetime | None, field_name: str) -> datetime | None:
@@ -206,12 +210,13 @@ class ReviewContext(BaseModel):
     """Context for performing a code review.
 
     Combines the merge request data with linked tasks
-    to provide full context for the AI reviewer.
+    and optional project profile to provide full context for the AI reviewer.
 
     Attributes:
         mr: The merge request to review.
         tasks: Linked tasks discovered via all strategies.
         repository: Repository name in owner/repo format.
+        project_profile: Discovery profile for project context.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -219,6 +224,9 @@ class ReviewContext(BaseModel):
     mr: MergeRequest = Field(..., description="The merge request to review")
     tasks: tuple[LinkedTask, ...] = Field(default=(), description="Linked tasks")
     repository: str = Field(..., min_length=1, description="Repository name (owner/repo)")
+    project_profile: ProjectProfile | None = Field(
+        default=None, description="Discovery profile for project context"
+    )
 
     @field_validator("repository")
     @classmethod
@@ -478,6 +486,20 @@ class ReviewResult(BaseModel):
         if self.task_alignment == TaskAlignmentStatus.MISALIGNED:
             return False
         return None
+
+
+# Deferred model rebuild — resolves forward reference to ProjectProfile
+# which cannot be imported at module level due to circular dependency:
+# core.models → discovery.models → discovery.__init__ → orchestrator → conversation → core.models
+def _rebuild_models() -> None:
+    """Rebuild ReviewContext to resolve forward references."""
+    from ai_reviewer.discovery.models import ProjectProfile  # noqa: PLC0415
+
+    ReviewContext.model_rebuild(_types_namespace={"ProjectProfile": ProjectProfile})
+
+
+_rebuild_models()
+del _rebuild_models  # keep module namespace clean
 
 
 # Public API - explicitly define what should be imported from this module

--- a/src/ai_reviewer/integrations/prompts.py
+++ b/src/ai_reviewer/integrations/prompts.py
@@ -88,6 +88,14 @@ are from previous AI reviews
 indented with "> "). Understand the full thread context before commenting. If a \
 discussion thread already reached a resolution, do not reopen it
 - Respond in the language specified in the user prompt
+
+## Project Context Awareness
+
+If a "Project Context" section is provided in the user prompt:
+- Respect automated checks. Do NOT comment on issues that CI tools already handle.
+- If "Skip" items are listed, do not comment on those categories.
+- Focus your review effort on "Focus" items — these are gaps in automation.
+- Follow any listed "Conventions" when evaluating code style.
 """
 
 
@@ -486,6 +494,11 @@ def build_review_prompt(context: ReviewContext, settings: Settings) -> str:
     # 0. Language Instruction (first, so it's prominent)
     language_instruction = build_language_instruction(context, settings)
     parts.append(f"## Language\n{language_instruction}")
+
+    # 0.5. Project Context (from Discovery)
+    if context.project_profile:
+        parts.append("\n## Project Context")
+        parts.append(context.project_profile.to_prompt_context())
 
     # 1. Linked Task Context
     if len(context.tasks) == 1:


### PR DESCRIPTION
- Add project_profile field to ReviewContext (deferred model_rebuild to break circular import: core.models → discovery → conversation → core.models)
- Add "Project Context" section to build_review_prompt() when profile exists
- Add "Project Context Awareness" block to SYSTEM_PROMPT instructing LLM to skip CI-covered categories and focus on automation gaps

