### PR TITLE
feat: add Discovery step to review pipeline (task 3.2)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: 'Group comments into threaded dialogues in AI prompt'
     required: false
     default: 'true'
+  discovery_enabled:
+    description: 'Enable project discovery before review'
+    required: false
+    default: 'true'
 
 runs:
   using: 'docker'
@@ -61,4 +65,5 @@ runs:
     AI_REVIEWER_REVIEW_INCLUDE_BOT_COMMENTS: ${{ inputs.review_include_bot_comments }}
     AI_REVIEWER_REVIEW_POST_INLINE_COMMENTS: ${{ inputs.review_post_inline_comments }}
     AI_REVIEWER_REVIEW_ENABLE_DIALOGUE: ${{ inputs.review_enable_dialogue }}
+    AI_REVIEWER_DISCOVERY_ENABLED: ${{ inputs.discovery_enabled }}
     GITHUB_ACTIONS: 'true'

--- a/src/ai_reviewer/core/config.py
+++ b/src/ai_reviewer/core/config.py
@@ -294,6 +294,13 @@ class Settings(BaseSettings):
         description="Group comments into threaded dialogues in AI prompt",
     )
 
+    # Discovery
+    discovery_enabled: bool = Field(
+        default=True,
+        validation_alias=AliasChoices("AI_REVIEWER_DISCOVERY_ENABLED", "DISCOVERY_ENABLED"),
+        description="Enable project discovery before review",
+    )
+
     # Inline comments
     review_post_inline_comments: bool = Field(
         default=True,

--- a/src/ai_reviewer/reviewer.py
+++ b/src/ai_reviewer/reviewer.py
@@ -25,6 +25,7 @@ from ai_reviewer.integrations.gemini import analyze_code_changes
 if TYPE_CHECKING:
     from ai_reviewer.core.config import Settings
     from ai_reviewer.core.models import CodeIssue, FileChange, ReviewResult
+    from ai_reviewer.discovery.models import ProjectProfile
     from ai_reviewer.integrations.base import GitProvider
 
 logger = logging.getLogger(__name__)
@@ -118,6 +119,13 @@ def review_pull_request(
     try:
         logger.info("Starting review for MR #%s in %s", mr_id, repo_name)
 
+        # 0. Discovery step (fail-open)
+        profile = (
+            _run_discovery(provider, repo_name, mr_id, settings)
+            if settings.discovery_enabled
+            else None
+        )
+
         # 1. Fetch MR data
         mr = provider.get_merge_request(repo_name, mr_id)
         if not mr:
@@ -138,7 +146,7 @@ def review_pull_request(
             logger.info("No linked tasks found")
 
         # 3. Build context
-        context = ReviewContext(mr=mr, tasks=tasks, repository=repo_name)
+        context = ReviewContext(mr=mr, tasks=tasks, repository=repo_name, project_profile=profile)
 
         # 4. Analyze with AI
         result = analyze_code_changes(context, settings)
@@ -177,6 +185,52 @@ def review_pull_request(
         # Fail Open strategy: Try to post a failure comment, but don't crash the CI hard
         # unless it's a critical configuration error.
         _post_error_comment(provider, repo_name, mr_id, e)
+
+
+def _run_discovery(
+    provider: GitProvider,
+    repo_name: str,
+    mr_id: int,
+    settings: Settings,
+) -> ProjectProfile | None:
+    """Run the Discovery pipeline, fail-open on any error.
+
+    Args:
+        provider: Git provider (triple inheritance: Git + Repository + Conversation).
+        repo_name: Repository identifier.
+        mr_id: Merge/Pull request number.
+        settings: Application settings.
+
+    Returns:
+        ProjectProfile if discovery succeeds, None otherwise.
+    """
+    from ai_reviewer.discovery import DiscoveryOrchestrator  # noqa: PLC0415
+    from ai_reviewer.llm.gemini import GeminiProvider  # noqa: PLC0415
+
+    try:
+        llm = GeminiProvider(
+            api_key=settings.google_api_key.get_secret_value(),
+            model_name=settings.gemini_model,
+        )
+        # GitHubClient/GitLabClient implement RepositoryProvider + ConversationProvider
+        # via triple inheritance, so the cast is safe at runtime.
+        discovery = DiscoveryOrchestrator(
+            repo_provider=provider,  # type: ignore[arg-type]
+            conversation=provider,  # type: ignore[arg-type]
+            llm=llm,
+        )
+        profile = discovery.discover(repo_name, mr_id)
+        tool_count = len(profile.ci_insights.detected_tools) if profile.ci_insights else 0
+        logger.info(
+            "Discovery: %s project, %d CI tool(s)",
+            profile.platform_data.primary_language,
+            tool_count,
+        )
+    except Exception:
+        logger.warning("Discovery failed, continuing without profile", exc_info=True)
+        return None
+    else:
+        return profile
 
 
 def _post_error_comment(

--- a/tests/e2e/test_review_flow.py
+++ b/tests/e2e/test_review_flow.py
@@ -40,6 +40,7 @@ class TestReviewFlow:
         settings.review_include_bot_comments = True
         settings.review_enable_dialogue = True
         settings.review_post_inline_comments = True
+        settings.discovery_enabled = False
         return settings
 
     @pytest.fixture


### PR DESCRIPTION
⏺ Коміт 69f1fd0 готовий. Task 3.2 виконана:
                                                                                                                        
  - _run_discovery() в reviewer.py — fail-open, deferred imports, triple-inheritance type: ignore                       
  - discovery_enabled: bool = True в config.py з AI_REVIEWER_DISCOVERY_ENABLED env var
  - action.yml — новий input + env mapping                                                                              
  - e2e тести — discovery_enabled = False в mock settings (щоб не ламати існуючі тести)
  - 788 passed, ruff ✓, mypy ✓


- Add _run_discovery() to reviewer.py with fail-open error handling
- Discovery runs before MR fetch, passes ProjectProfile to ReviewContext
- Add discovery_enabled setting (default: true) with env var support
- Update action.yml with discovery_enabled input
- Deferred imports in _run_discovery() to avoid circular dependency


