### PR TITLE
Оновлення моделей

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ GOOGLE_API_KEY=
 
 # Gemini model (default: gemini-2.5-flash)
 # GEMINI_MODEL=gemini-2.5-flash
-# GEMINI_MODEL_FALLBACK=gemini-3-flash-preview
+# GEMINI_MODEL_FALLBACK=gemini-3.1-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview
 
 # =============================================================================
 # Git Platform (one required)

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Full documentation available in **6 languages**:
 | `AI_REVIEWER_LANGUAGE` | `en` | Response language (ISO 639 code) |
 | `AI_REVIEWER_LANGUAGE_MODE` | `adaptive` | `adaptive` (detect from PR) or `fixed` |
 | `AI_REVIEWER_GEMINI_MODEL` | `gemini-2.5-flash` | Gemini model to use |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | `gemini-3-flash-preview` | Fallback model when primary is unavailable |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | `gemini-3.1-flash-preview` | Fallback model chain (comma-separated) |
 | `AI_REVIEWER_LOG_LEVEL` | `INFO` | Logging level |
 | `AI_REVIEWER_REVIEW_MAX_COMMENT_CHARS` | `3000` | Max characters per comment |
 | `AI_REVIEWER_REVIEW_INCLUDE_BOT_COMMENTS` | `true` | Include bot comments in context |
@@ -210,7 +210,7 @@ uv run mkdocs serve
 
 ## 💰 Cost Estimate
 
-Using Gemini 3 Flash Preview:
+Using Gemini 2.5 Flash:
 - **Input:** $0.075 / 1M tokens
 - **Output:** $0.30 / 1M tokens
 - **Average review:** ~$0.002 (1,500 tokens)

--- a/action.yml
+++ b/action.yml
@@ -26,9 +26,9 @@ inputs:
     required: false
     default: 'gemini-2.5-flash'
   gemini_model_fallback:
-    description: 'Fallback model when primary is unavailable (empty to disable)'
+    description: 'Comma-separated fallback model chain (empty to disable)'
     required: false
-    default: 'gemini-3-flash-preview'
+    default: 'gemini-3.1-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview'
   log_level:
     description: 'Log level (DEBUG, INFO, WARNING, ERROR)'
     required: false

--- a/docs/de/configuration.md
+++ b/docs/de/configuration.md
@@ -54,17 +54,17 @@ Alle Einstellungen werden über Umgebungsvariablen konfiguriert.
 | Variable | Beschreibung | Standard |
 |----------|--------------|----------|
 | `AI_REVIEWER_GEMINI_MODEL` | Gemini-Modell | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback-Modell bei Nichtverfügbarkeit des primären | `gemini-3-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `AI_REVIEWER_REVIEW_SPLIT_THRESHOLD` | Zeichenlimit für Code+Test-Split-Review | `30000` |
 
 **Verfügbare Modelle:**
 
-| Modell | Beschreibung | Kosten |
-|--------|--------------|--------|
-| `gemini-3-flash-preview` | Neuestes Flash (Preview) | $0.075 / 1M Input |
-| `gemini-2.5-flash` | Schnell, günstig, stabil | $0.075 / 1M Input |
-| `gemini-2.0-flash` | Vorherige Version | $0.075 / 1M Input |
-| `gemini-1.5-pro` | Leistungsstärker | $1.25 / 1M Input |
+| Model | Description | Cost |
+|-------|-------------|------|
+| `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
+| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
+| `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
+| `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
 
 !!! note "Preisgenauigkeit"
     Die Preise sind zum Release-Datum angegeben und können sich ändern.

--- a/docs/de/configuration.md
+++ b/docs/de/configuration.md
@@ -54,17 +54,17 @@ Alle Einstellungen werden über Umgebungsvariablen konfiguriert.
 | Variable | Beschreibung | Standard |
 |----------|--------------|----------|
 | `AI_REVIEWER_GEMINI_MODEL` | Gemini-Modell | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback-Modellkette (durch Komma getrennt) | `gemini-3.1-flash-preview` |
 | `AI_REVIEWER_REVIEW_SPLIT_THRESHOLD` | Zeichenlimit für Code+Test-Split-Review | `30000` |
 
 **Verfügbare Modelle:**
 
-| Model | Description | Cost |
-|-------|-------------|------|
-| `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
-| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
-| `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
-| `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
+| Modell | Beschreibung | Kosten |
+|--------|-------------|--------|
+| `gemini-2.5-flash` | Schnell, stabil, mit Argumentationsfähigkeit (Standard) | $0.075 / 1M Input |
+| `gemini-3.1-flash-preview` | Frontier-Klasse Flash (Vorschau) | $0.075 / 1M Input |
+| `gemini-2.5-flash-lite` | Schnellste und günstigste in 2.5 | $0.01875 / 1M Input |
+| `gemini-2.5-pro` | Leistungsstärkste, tiefes Reasoning | $1.25 / 1M Input |
 
 !!! note "Preisgenauigkeit"
     Die Preise sind zum Release-Datum angegeben und können sich ändern.

--- a/docs/de/github.md
+++ b/docs/de/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Max. MR-Kommentarzeichen im Prompt | `3000` |
 | `review_include_bot_comments` | Bot-Kommentare in Prompt einbeziehen | `true` |
 | `review_post_inline_comments` | Inline-Kommentare an Codezeilen posten | `true` |
-| `gemini_model_fallback` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
+| `gemini_model_fallback` | Fallback-Modellkette (durch Komma getrennt) | `gemini-3.1-flash-preview` |
 | `review_enable_dialogue` | Kommentare in Dialoge gruppieren | `true` |
 | `discovery_enabled` | Project Discovery aktivieren | `true` |
 | `discovery_verbose` | Discovery-Kommentar immer posten | `false` |

--- a/docs/de/github.md
+++ b/docs/de/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Max. MR-Kommentarzeichen im Prompt | `3000` |
 | `review_include_bot_comments` | Bot-Kommentare in Prompt einbeziehen | `true` |
 | `review_post_inline_comments` | Inline-Kommentare an Codezeilen posten | `true` |
-| `gemini_model_fallback` | Fallback-Modell bei Kontingenterschöpfung | `gemini-3-flash-preview` |
+| `gemini_model_fallback` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `review_enable_dialogue` | Kommentare in Dialoge gruppieren | `true` |
 | `discovery_enabled` | Project Discovery aktivieren | `true` |
 | `discovery_verbose` | Discovery-Kommentar immer posten | `false` |

--- a/docs/de/troubleshooting.md
+++ b/docs/de/troubleshooting.md
@@ -283,7 +283,7 @@ echo $GITHUB_TOKEN | head -c 10
 
 ```bash
 # Gemini API testen
-curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
+curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"contents":[{"parts":[{"text":"Hello"}]}]}'
 ```

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -58,17 +58,17 @@ All settings are configured via environment variables.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `AI_REVIEWER_GEMINI_MODEL` | Gemini model | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model when primary is unavailable | `gemini-3-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `AI_REVIEWER_REVIEW_SPLIT_THRESHOLD` | Char threshold for code+test split review | `30000` |
 
 **Available models:**
 
 | Model | Description | Cost |
 |-------|-------------|------|
-| `gemini-3-flash-preview` | Latest Flash (preview) | $0.075 / 1M input |
-| `gemini-2.5-flash` | Fast, cheap, stable | $0.075 / 1M input |
-| `gemini-2.0-flash` | Previous version | $0.075 / 1M input |
-| `gemini-1.5-pro` | More powerful | $1.25 / 1M input |
+| `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
+| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
+| `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
+| `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
 
 !!! note "Pricing accuracy"
     Prices are listed as of the release date and may change.

--- a/docs/en/github.md
+++ b/docs/en/github.md
@@ -222,7 +222,7 @@ jobs:
 | `language` | Response language | `en` |
 | `language_mode` | Language mode | `adaptive` |
 | `gemini_model` | Gemini model | `gemini-2.5-flash` |
-| `gemini_model_fallback` | Fallback model on quota exhaustion | `gemini-3-flash-preview` |
+| `gemini_model_fallback` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `log_level` | Log level | `INFO` |
 | `review_max_comment_chars` | Max MR comment chars in prompt | `3000` |
 | `review_include_bot_comments` | Include bot comments in prompt | `true` |

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -283,7 +283,7 @@ echo $GITHUB_TOKEN | head -c 10
 
 ```bash
 # Test Gemini API
-curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
+curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"contents":[{"parts":[{"text":"Hello"}]}]}'
 ```

--- a/docs/es/configuration.md
+++ b/docs/es/configuration.md
@@ -54,17 +54,17 @@ Todas las configuraciones se hacen mediante variables de entorno.
 | Variable | Descripción | Por defecto |
 |----------|-------------|-------------|
 | `AI_REVIEWER_GEMINI_MODEL` | Modelo Gemini | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Cadena de modelos de respaldo (separados por comas) | `gemini-3.1-flash-preview` |
 | `AI_REVIEWER_REVIEW_SPLIT_THRESHOLD` | Umbral de caracteres para revisión dividida código+tests | `30000` |
 
 **Modelos disponibles:**
 
-| Model | Description | Cost |
-|-------|-------------|------|
-| `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
-| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
-| `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
-| `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
+| Modelo | Descripción | Costo |
+|--------|-------------|-------|
+| `gemini-2.5-flash` | Rápido, estable, con razonamiento (predeterminado) | $0.075 / 1M entrada |
+| `gemini-3.1-flash-preview` | Flash de clase frontier (vista previa) | $0.075 / 1M entrada |
+| `gemini-2.5-flash-lite` | El más rápido y económico en 2.5 | $0.01875 / 1M entrada |
+| `gemini-2.5-pro` | El más potente, razonamiento profundo | $1.25 / 1M entrada |
 
 !!! note "Precisión de precios"
     Los precios están listados a la fecha de lanzamiento y pueden cambiar.

--- a/docs/es/configuration.md
+++ b/docs/es/configuration.md
@@ -54,17 +54,17 @@ Todas las configuraciones se hacen mediante variables de entorno.
 | Variable | Descripción | Por defecto |
 |----------|-------------|-------------|
 | `AI_REVIEWER_GEMINI_MODEL` | Modelo Gemini | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Modelo fallback cuando el primario no está disponible | `gemini-3-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `AI_REVIEWER_REVIEW_SPLIT_THRESHOLD` | Umbral de caracteres para revisión dividida código+tests | `30000` |
 
 **Modelos disponibles:**
 
-| Modelo | Descripción | Costo |
-|--------|-------------|-------|
-| `gemini-3-flash-preview` | Último Flash (preview) | $0.075 / 1M entrada |
-| `gemini-2.5-flash` | Rápido, económico, estable | $0.075 / 1M entrada |
-| `gemini-2.0-flash` | Versión anterior | $0.075 / 1M entrada |
-| `gemini-1.5-pro` | Más potente | $1.25 / 1M entrada |
+| Model | Description | Cost |
+|-------|-------------|------|
+| `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
+| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
+| `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
+| `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
 
 !!! note "Precisión de precios"
     Los precios están listados a la fecha de lanzamiento y pueden cambiar.

--- a/docs/es/github.md
+++ b/docs/es/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Máx. caracteres de comentario MR en el prompt | `3000` |
 | `review_include_bot_comments` | Incluir comentarios de bots en el prompt | `true` |
 | `review_post_inline_comments` | Publicar comentarios inline en líneas | `true` |
-| `gemini_model_fallback` | Modelo de respaldo por agotamiento de cuota | `gemini-3-flash-preview` |
+| `gemini_model_fallback` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `review_enable_dialogue` | Agrupar comentarios en diálogos | `true` |
 | `discovery_enabled` | Activar project discovery | `true` |
 | `discovery_verbose` | Publicar siempre comentario de discovery | `false` |

--- a/docs/es/github.md
+++ b/docs/es/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Máx. caracteres de comentario MR en el prompt | `3000` |
 | `review_include_bot_comments` | Incluir comentarios de bots en el prompt | `true` |
 | `review_post_inline_comments` | Publicar comentarios inline en líneas | `true` |
-| `gemini_model_fallback` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
+| `gemini_model_fallback` | Cadena de modelos de respaldo (separados por comas) | `gemini-3.1-flash-preview` |
 | `review_enable_dialogue` | Agrupar comentarios en diálogos | `true` |
 | `discovery_enabled` | Activar project discovery | `true` |
 | `discovery_verbose` | Publicar siempre comentario de discovery | `false` |

--- a/docs/es/troubleshooting.md
+++ b/docs/es/troubleshooting.md
@@ -283,7 +283,7 @@ echo $GITHUB_TOKEN | head -c 10
 
 ```bash
 # Probar API de Gemini
-curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
+curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"contents":[{"parts":[{"text":"Hello"}]}]}'
 ```

--- a/docs/it/configuration.md
+++ b/docs/it/configuration.md
@@ -54,17 +54,17 @@ Tutte le impostazioni vengono configurate tramite variabili d'ambiente.
 | Variabile | Descrizione | Default |
 |-----------|-------------|---------|
 | `AI_REVIEWER_GEMINI_MODEL` | Modello Gemini | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Modello fallback quando il primario non è disponibile | `gemini-3-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `AI_REVIEWER_REVIEW_SPLIT_THRESHOLD` | Soglia caratteri per review split codice+test | `30000` |
 
 **Modelli disponibili:**
 
-| Modello | Descrizione | Costo |
-|---------|-------------|-------|
-| `gemini-3-flash-preview` | Ultimo Flash (preview) | $0.075 / 1M input |
-| `gemini-2.5-flash` | Veloce, economico, stabile | $0.075 / 1M input |
-| `gemini-2.0-flash` | Versione precedente | $0.075 / 1M input |
-| `gemini-1.5-pro` | Piu potente | $1.25 / 1M input |
+| Model | Description | Cost |
+|-------|-------------|------|
+| `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
+| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
+| `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
+| `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
 
 !!! note "Precisione prezzi"
     I prezzi sono indicati alla data di release e possono cambiare.

--- a/docs/it/configuration.md
+++ b/docs/it/configuration.md
@@ -54,17 +54,17 @@ Tutte le impostazioni vengono configurate tramite variabili d'ambiente.
 | Variabile | Descrizione | Default |
 |-----------|-------------|---------|
 | `AI_REVIEWER_GEMINI_MODEL` | Modello Gemini | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Catena di modelli di fallback (separati da virgola) | `gemini-3.1-flash-preview` |
 | `AI_REVIEWER_REVIEW_SPLIT_THRESHOLD` | Soglia caratteri per review split codice+test | `30000` |
 
 **Modelli disponibili:**
 
-| Model | Description | Cost |
-|-------|-------------|------|
-| `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
-| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
-| `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
-| `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
+| Modello | Descrizione | Costo |
+|---------|-------------|-------|
+| `gemini-2.5-flash` | Veloce, stabile, con ragionamento (predefinito) | $0.075 / 1M input |
+| `gemini-3.1-flash-preview` | Flash di classe frontier (anteprima) | $0.075 / 1M input |
+| `gemini-2.5-flash-lite` | Il più veloce e economico in 2.5 | $0.01875 / 1M input |
+| `gemini-2.5-pro` | Più potente, con ragionamento profondo | $1.25 / 1M input |
 
 !!! note "Precisione prezzi"
     I prezzi sono indicati alla data di release e possono cambiare.

--- a/docs/it/github.md
+++ b/docs/it/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Max caratteri commento MR nel prompt | `3000` |
 | `review_include_bot_comments` | Includi commenti bot nel prompt | `true` |
 | `review_post_inline_comments` | Pubblica commenti inline sulle righe | `true` |
-| `gemini_model_fallback` | Modello di riserva per esaurimento quota | `gemini-3-flash-preview` |
+| `gemini_model_fallback` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `review_enable_dialogue` | Raggruppare i commenti in dialoghi | `true` |
 | `discovery_enabled` | Attivare project discovery | `true` |
 | `discovery_verbose` | Pubblicare sempre il commento discovery | `false` |

--- a/docs/it/github.md
+++ b/docs/it/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Max caratteri commento MR nel prompt | `3000` |
 | `review_include_bot_comments` | Includi commenti bot nel prompt | `true` |
 | `review_post_inline_comments` | Pubblica commenti inline sulle righe | `true` |
-| `gemini_model_fallback` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
+| `gemini_model_fallback` | Catena di modelli di fallback (separati da virgola) | `gemini-3.1-flash-preview` |
 | `review_enable_dialogue` | Raggruppare i commenti in dialoghi | `true` |
 | `discovery_enabled` | Attivare project discovery | `true` |
 | `discovery_verbose` | Pubblicare sempre il commento discovery | `false` |

--- a/docs/it/troubleshooting.md
+++ b/docs/it/troubleshooting.md
@@ -283,7 +283,7 @@ echo $GITHUB_TOKEN | head -c 10
 
 ```bash
 # Testa Gemini API
-curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
+curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"contents":[{"parts":[{"text":"Hello"}]}]}'
 ```

--- a/docs/sr/configuration.md
+++ b/docs/sr/configuration.md
@@ -54,17 +54,17 @@ Sva podešavanja se konfigurišu putem varijabli okruženja.
 | Varijabla | Opis | Podrazumijevano |
 |----------|-------------|---------|
 | `AI_REVIEWER_GEMINI_MODEL` | Gemini model | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Lanac rezervnih modela (odvojenih zarezima) | `gemini-3.1-flash-preview` |
 | `AI_REVIEWER_REVIEW_SPLIT_THRESHOLD` | Prag karaktera za podijeljen pregled kod+testovi | `30000` |
 
 **Dostupni modeli:**
 
-| Model | Description | Cost |
-|-------|-------------|------|
-| `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
-| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
-| `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
-| `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
+| Model | Opis | Cena |
+|-------|------|------|
+| `gemini-2.5-flash` | Brz, stabilan, sa sposobnošću rasuđivanja (podrazumevano) | $0.075 / 1M ulaz |
+| `gemini-3.1-flash-preview` | Frontier-klasa flash (pregled) | $0.075 / 1M ulaz |
+| `gemini-2.5-flash-lite` | Najbrži i najjeftiniji u 2.5 | $0.01875 / 1M ulaz |
+| `gemini-2.5-pro` | Najmoćniji, sa dubokim rasuđivanjem | $1.25 / 1M ulaz |
 
 !!! note "Tačnost cijena"
     Cijene su navedene na datum izdanja i mogu se promijeniti.

--- a/docs/sr/configuration.md
+++ b/docs/sr/configuration.md
@@ -54,17 +54,17 @@ Sva podešavanja se konfigurišu putem varijabli okruženja.
 | Varijabla | Opis | Podrazumijevano |
 |----------|-------------|---------|
 | `AI_REVIEWER_GEMINI_MODEL` | Gemini model | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model kada primarni nije dostupan | `gemini-3-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `AI_REVIEWER_REVIEW_SPLIT_THRESHOLD` | Prag karaktera za podijeljen pregled kod+testovi | `30000` |
 
 **Dostupni modeli:**
 
-| Model | Opis | Cijena |
+| Model | Description | Cost |
 |-------|-------------|------|
-| `gemini-3-flash-preview` | Najnoviji Flash (preview) | $0.075 / 1M ulaz |
-| `gemini-2.5-flash` | Brz, jeftin, stabilan | $0.075 / 1M ulaz |
-| `gemini-2.0-flash` | Prethodna verzija | $0.075 / 1M ulaz |
-| `gemini-1.5-pro` | Moćniji | $1.25 / 1M ulaz |
+| `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
+| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
+| `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
+| `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
 
 !!! note "Tačnost cijena"
     Cijene su navedene na datum izdanja i mogu se promijeniti.

--- a/docs/sr/github.md
+++ b/docs/sr/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Maks. znakova komentara MR-a u promptu | `3000` |
 | `review_include_bot_comments` | Uključi komentare botova u prompt | `true` |
 | `review_post_inline_comments` | Objavi inline komentare na linijama | `true` |
-| `gemini_model_fallback` | Rezervni model pri iscrpljivanju kvote | `gemini-3-flash-preview` |
+| `gemini_model_fallback` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `review_enable_dialogue` | Grupisati komentare u dijaloge | `true` |
 | `discovery_enabled` | Aktivirati project discovery | `true` |
 | `discovery_verbose` | Uvijek objaviti discovery komentar | `false` |

--- a/docs/sr/github.md
+++ b/docs/sr/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Maks. znakova komentara MR-a u promptu | `3000` |
 | `review_include_bot_comments` | Uključi komentare botova u prompt | `true` |
 | `review_post_inline_comments` | Objavi inline komentare na linijama | `true` |
-| `gemini_model_fallback` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
+| `gemini_model_fallback` | Lanac rezervnih modela (odvojenih zarezima) | `gemini-3.1-flash-preview` |
 | `review_enable_dialogue` | Grupisati komentare u dijaloge | `true` |
 | `discovery_enabled` | Aktivirati project discovery | `true` |
 | `discovery_verbose` | Uvijek objaviti discovery komentar | `false` |

--- a/docs/sr/troubleshooting.md
+++ b/docs/sr/troubleshooting.md
@@ -283,7 +283,7 @@ echo $GITHUB_TOKEN | head -c 10
 
 ```bash
 # Test Gemini API
-curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
+curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"contents":[{"parts":[{"text":"Hello"}]}]}'
 ```

--- a/docs/uk/configuration.md
+++ b/docs/uk/configuration.md
@@ -58,17 +58,17 @@
 | Змінна | Опис | Default |
 |--------|------|---------|
 | `AI_REVIEWER_GEMINI_MODEL` | Модель Gemini | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback модель, коли основна недоступна | `gemini-3-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `AI_REVIEWER_REVIEW_SPLIT_THRESHOLD` | Поріг символів для split review (код+тести окремо) | `30000` |
 
 **Доступні моделі:**
 
-| Модель | Опис | Вартість |
-|--------|------|----------|
-| `gemini-3-flash-preview` | Найновіша Flash (preview) | $0.075 / 1M input |
-| `gemini-2.5-flash` | Швидка, дешева, стабільна | $0.075 / 1M input |
-| `gemini-2.0-flash` | Попередня версія | $0.075 / 1M input |
-| `gemini-1.5-pro` | Потужніша | $1.25 / 1M input |
+| Model | Description | Cost |
+|-------|-------------|------|
+| `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
+| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
+| `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
+| `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
 
 !!! note "Актуальність цін"
     Вартості вказані на день релізу і можуть змінюватись.

--- a/docs/uk/configuration.md
+++ b/docs/uk/configuration.md
@@ -58,17 +58,17 @@
 | Змінна | Опис | Default |
 |--------|------|---------|
 | `AI_REVIEWER_GEMINI_MODEL` | Модель Gemini | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Ланцюжок fallback-моделей (через кому) | `gemini-3.1-flash-preview` |
 | `AI_REVIEWER_REVIEW_SPLIT_THRESHOLD` | Поріг символів для split review (код+тести окремо) | `30000` |
 
 **Доступні моделі:**
 
-| Model | Description | Cost |
-|-------|-------------|------|
-| `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
-| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
-| `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
-| `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
+| Модель | Опис | Ціна |
+|--------|------|------|
+| `gemini-2.5-flash` | Швидка, стабільна, з reasoning (за замовчуванням) | $0.075 / 1M input |
+| `gemini-3.1-flash-preview` | Frontier-клас flash (preview) | $0.075 / 1M input |
+| `gemini-2.5-flash-lite` | Найшвидша і найдешевша в 2.5 | $0.01875 / 1M input |
+| `gemini-2.5-pro` | Найпотужніша, з глибоким reasoning | $1.25 / 1M input |
 
 !!! note "Актуальність цін"
     Вартості вказані на день релізу і можуть змінюватись.

--- a/docs/uk/github.md
+++ b/docs/uk/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Макс. символів коментаря MR у промпті | `3000` |
 | `review_include_bot_comments` | Включати коментарі ботів у промпт | `true` |
 | `review_post_inline_comments` | Публікувати inline коментарі до рядків | `true` |
-| `gemini_model_fallback` | Fallback модель при вичерпанні квоти | `gemini-3-flash-preview` |
+| `gemini_model_fallback` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
 | `review_enable_dialogue` | Групувати коментарі в діалоги | `true` |
 | `discovery_enabled` | Увімкнути project discovery | `true` |
 | `discovery_verbose` | Завжди публікувати discovery коментар | `false` |

--- a/docs/uk/github.md
+++ b/docs/uk/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Макс. символів коментаря MR у промпті | `3000` |
 | `review_include_bot_comments` | Включати коментарі ботів у промпт | `true` |
 | `review_post_inline_comments` | Публікувати inline коментарі до рядків | `true` |
-| `gemini_model_fallback` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview` |
+| `gemini_model_fallback` | Ланцюжок fallback-моделей (через кому) | `gemini-3.1-flash-preview` |
 | `review_enable_dialogue` | Групувати коментарі в діалоги | `true` |
 | `discovery_enabled` | Увімкнути project discovery | `true` |
 | `discovery_verbose` | Завжди публікувати discovery коментар | `false` |

--- a/docs/uk/troubleshooting.md
+++ b/docs/uk/troubleshooting.md
@@ -283,7 +283,7 @@ echo $GITHUB_TOKEN | head -c 10
 
 ```bash
 # Перевірити Gemini API
-curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
+curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$AI_REVIEWER_GOOGLE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"contents":[{"parts":[{"text":"Hello"}]}]}'
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,7 +28,7 @@ Or copy the job from `gitlab-ci.yml` to your pipeline.
 |----------|-------------|---------|
 | `AI_REVIEWER_LANGUAGE` | Response language (ISO 639 code) | `en` |
 | `AI_REVIEWER_LANGUAGE_MODE` | `adaptive` (detect from PR) or `fixed` | `adaptive` |
-| `AI_REVIEWER_GEMINI_MODEL` | Gemini model to use | `gemini-3-flash-preview` |
+| `AI_REVIEWER_GEMINI_MODEL` | Gemini model to use | `gemini-2.5-flash` |
 | `AI_REVIEWER_LOG_LEVEL` | Logging verbosity | `INFO` |
 | `AI_REVIEWER_DISCOVERY_ENABLED` | Enable project discovery | `true` |
 
@@ -106,6 +106,6 @@ The reviewer displays estimated costs in the review footer. Typical costs:
 
 | Model | ~2000 tokens | ~10000 tokens |
 |-------|--------------|---------------|
-| gemini-3-flash-preview | ~$0.0002 | ~$0.001 |
 | gemini-2.5-flash | ~$0.0002 | ~$0.001 |
-| gemini-1.5-pro | ~$0.005 | ~$0.025 |
+| gemini-3.1-flash-preview | ~$0.0002 | ~$0.001 |
+| gemini-2.5-pro | ~$0.005 | ~$0.025 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-reviewbot"
-version = "1.0.0b8"
+version = "1.0.0b9"
 description = "AI-powered code review agent for CI/CD pipelines"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ai_reviewer/core/config.py
+++ b/src/ai_reviewer/core/config.py
@@ -227,9 +227,9 @@ class Settings(BaseSettings):
         description="Gemini model to use for analysis",
     )
     gemini_model_fallback: str | None = Field(
-        default="gemini-3-flash-preview",
+        default="gemini-3.1-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview",
         validation_alias=AliasChoices("AI_REVIEWER_GEMINI_MODEL_FALLBACK", "GEMINI_MODEL_FALLBACK"),
-        description="Fallback model when primary is unavailable (None to disable)",
+        description="Comma-separated fallback model chain (empty to disable)",
     )
     log_level: LogLevel = Field(
         default="INFO",
@@ -345,6 +345,17 @@ class Settings(BaseSettings):
         """
         raw = self.google_api_key.get_secret_value()
         return [k.strip() for k in raw.split(",") if k.strip()]
+
+    @property
+    def fallback_models(self) -> list[str]:
+        """Parse comma-separated fallback model names.
+
+        Returns:
+            List of model name strings (may be empty if fallback disabled).
+        """
+        if not self.gemini_model_fallback:
+            return []
+        return [m.strip() for m in self.gemini_model_fallback.split(",") if m.strip()]
 
     @model_validator(mode="after")
     def _validate_individual_keys(self) -> Settings:

--- a/src/ai_reviewer/integrations/gemini.py
+++ b/src/ai_reviewer/integrations/gemini.py
@@ -31,7 +31,12 @@ from ai_reviewer.llm.gemini import (
     calculate_cost,
 )
 from ai_reviewer.llm.key_pool import KeyPool, RotatingGeminiProvider
-from ai_reviewer.utils.retry import QuotaExhaustedError, RateLimitError, ServerError
+from ai_reviewer.utils.retry import (
+    AllModelsFailedError,
+    QuotaExhaustedError,
+    RateLimitError,
+    ServerError,
+)
 
 if TYPE_CHECKING:
     from pydantic import SecretStr
@@ -157,9 +162,10 @@ def _call_llm(
     prompt: str,
     system_prompt: str,
 ) -> ReviewResult:
-    """Call Gemini with key rotation and model fallback.
+    """Call Gemini with key rotation and model fallback chain.
 
-    Strategy: all keys on primary model, then all keys on fallback model.
+    Strategy: try each model in order (primary, then fallback chain),
+    rotating through all API keys per model before moving on.
 
     Args:
         key_pool: Pool of API keys to rotate through.
@@ -169,50 +175,46 @@ def _call_llm(
 
     Returns:
         ReviewResult with metrics attached.
+
+    Raises:
+        AllModelsFailedError: When all models in the chain fail.
+        ServerError: When primary fails and no fallback is configured.
+        RateLimitError: When primary fails and no fallback is configured.
+        QuotaExhaustedError: When primary fails and no fallback is configured.
     """
+    models = [settings.gemini_model, *settings.fallback_models]
+    failures: list[tuple[str, Exception]] = []
     fallback_reason: str | None = None
 
-    try:
-        provider = RotatingGeminiProvider(key_pool=key_pool, model_name=settings.gemini_model)
-        response = provider.generate(
-            prompt,
-            system_prompt=system_prompt,
-            response_schema=ReviewResult,
-        )
-    except (ServerError, RateLimitError, QuotaExhaustedError) as primary_err:
-        if not settings.gemini_model_fallback:
-            raise
-        logger.warning(
-            "Primary model %s failed (%s: %s). Trying fallback %s",
-            settings.gemini_model,
-            type(primary_err).__name__,
-            primary_err,
-            settings.gemini_model_fallback,
-        )
-        fallback_reason = f"{settings.gemini_model} \u2192 {type(primary_err).__name__}"
-        fallback_provider = RotatingGeminiProvider(
-            key_pool=key_pool,
-            model_name=settings.gemini_model_fallback,
-        )
+    for model in models:
         try:
-            response = fallback_provider.generate(
+            provider = RotatingGeminiProvider(key_pool=key_pool, model_name=model)
+            response = provider.generate(
                 prompt,
                 system_prompt=system_prompt,
                 response_schema=ReviewResult,
             )
-        except (ServerError, RateLimitError, QuotaExhaustedError) as fallback_err:
-            logger.exception(
-                "Fallback model %s also failed (%s). Both models exhausted.",
-                settings.gemini_model_fallback,
-                type(fallback_err).__name__,
+            break  # success
+        except (ServerError, RateLimitError, QuotaExhaustedError) as err:
+            failures.append((model, err))
+            logger.warning(
+                "Model %s failed (%s: %s). %d model(s) remaining in chain.",
+                model,
+                type(err).__name__,
+                str(err)[:120],
+                len(models) - len(failures),
             )
-            msg = (
-                f"Both models failed — primary {settings.gemini_model} "
-                f"({type(primary_err).__name__}) and fallback "
-                f"{settings.gemini_model_fallback} ({type(fallback_err).__name__}). "
-                f"Check your Gemini API quota at https://ai.dev/rate-limit"
-            )
-            raise QuotaExhaustedError(msg) from fallback_err
+            if len(failures) == 1:
+                fallback_reason = f"{model} \u2192 {type(err).__name__}"
+    else:
+        # All models exhausted
+        if len(failures) == 1:
+            # Single model (no fallback chain) — re-raise as-is
+            raise failures[0][1]
+        details = ", ".join(f"{m} ({type(e).__name__})" for m, e in failures)
+        is_quota = all(isinstance(e, QuotaExhaustedError) for _, e in failures)
+        msg = f"All {len(failures)} model(s) failed: {details}"
+        raise AllModelsFailedError(msg, is_quota=is_quota) from failures[-1][1]
 
     result = response.content
     assert isinstance(result, ReviewResult)  # guaranteed by response_schema

--- a/src/ai_reviewer/llm/base.py
+++ b/src/ai_reviewer/llm/base.py
@@ -55,7 +55,7 @@ class LLMProvider(ABC):
     @property
     @abstractmethod
     def model_name(self) -> str:
-        """Return the model identifier (e.g. ``gemini-3-flash-preview``)."""
+        """Return the model identifier (e.g. ``gemini-2.5-flash``)."""
         ...
 
     @overload

--- a/src/ai_reviewer/llm/gemini.py
+++ b/src/ai_reviewer/llm/gemini.py
@@ -42,21 +42,22 @@ logger = logging.getLogger(__name__)
 # Gemini pricing per 1M tokens (as of February 2026)
 # https://ai.google.dev/pricing
 GEMINI_PRICING: dict[str, dict[str, float]] = {
-    # Gemini 3 Flash (preview)
-    "gemini-3-flash-preview": {"input": 0.075, "output": 0.30},
-    # Gemini 2.5 Flash
+    # Gemini 3.1 (preview)
+    "gemini-3.1-flash-preview": {"input": 0.075, "output": 0.30},
+    "gemini-3.1-flash-lite-preview": {"input": 0.01875, "output": 0.075},
+    "gemini-3.1-pro-preview": {"input": 1.25, "output": 5.00},
+    # Gemini 2.5
     "gemini-2.5-flash": {"input": 0.075, "output": 0.30},
-    "gemini-2.5-flash-preview-05-20": {"input": 0.075, "output": 0.30},
+    "gemini-2.5-flash-lite": {"input": 0.01875, "output": 0.075},
+    "gemini-2.5-pro": {"input": 1.25, "output": 5.00},
     # Gemini 2.0 Flash
     "gemini-2.0-flash": {"input": 0.10, "output": 0.40},
     "gemini-2.0-flash-001": {"input": 0.10, "output": 0.40},
-    # Gemini 1.5 Flash
+    # Legacy models
     "gemini-1.5-flash": {"input": 0.075, "output": 0.30},
     "gemini-1.5-flash-latest": {"input": 0.075, "output": 0.30},
-    # Gemini 1.5 Pro
     "gemini-1.5-pro": {"input": 1.25, "output": 5.00},
     "gemini-1.5-pro-latest": {"input": 1.25, "output": 5.00},
-    # Gemini Pro (legacy)
     "gemini-pro": {"input": 0.50, "output": 1.50},
 }
 

--- a/src/ai_reviewer/reviewer.py
+++ b/src/ai_reviewer/reviewer.py
@@ -29,7 +29,7 @@ from ai_reviewer.discovery.comment import (
 from ai_reviewer.integrations.base import LineComment, ReviewSubmission, parse_diff_valid_lines
 from ai_reviewer.integrations.gemini import analyze_code_changes
 from ai_reviewer.utils.language import get_language_for_review
-from ai_reviewer.utils.retry import QuotaExhaustedError
+from ai_reviewer.utils.retry import AllModelsFailedError, QuotaExhaustedError
 
 if TYPE_CHECKING:
     from ai_reviewer.core.config import Settings
@@ -316,7 +316,7 @@ def _post_error_comment(
         error: The exception that caused the failure.
     """
     try:
-        if isinstance(error, QuotaExhaustedError):
+        if isinstance(error, AllModelsFailedError) and error.is_quota:
             error_msg = (
                 f"## \u26a0\ufe0f {BOT_NAME}: API Quota Exhausted\n\n"
                 "All configured Gemini models have exceeded their API quota.\n"
@@ -325,6 +325,17 @@ def _post_error_comment(
                 "- Wait for quota to reset (usually resets daily)\n"
                 "- Upgrade your [Gemini API plan](https://ai.google.dev/pricing)\n"
                 "- Re-run this workflow once quota is available\n"
+            )
+        elif isinstance(error, (AllModelsFailedError, QuotaExhaustedError)):
+            error_msg = (
+                f"## \u26a0\ufe0f {BOT_NAME}: All Models Unavailable\n\n"
+                "All configured Gemini models failed (server errors or rate limits).\n"
+                f"**Details:** `{error!s}`\n\n"
+                "**What to do:**\n"
+                "- Check [Gemini API status](https://status.cloud.google.com/)\n"
+                "- Re-run this workflow in a few minutes\n"
+                "- If the issue persists, check your "
+                "[API quota](https://ai.google.dev/pricing)\n"
             )
         else:
             error_msg = (

--- a/src/ai_reviewer/utils/retry.py
+++ b/src/ai_reviewer/utils/retry.py
@@ -109,6 +109,23 @@ class QuotaExhaustedError(Exception):
         self.quota_id = quota_id
 
 
+class AllModelsFailedError(Exception):
+    """All configured Gemini models failed (primary + fallback chain).
+
+    Wraps the list of per-model failures so the caller can determine
+    the dominant error category (quota vs server vs rate-limit).
+
+    Args:
+        message: Human-readable summary.
+        is_quota: True when **all** failures are QuotaExhaustedError.
+    """
+
+    def __init__(self, message: str, *, is_quota: bool = False) -> None:
+        """Initialize AllModelsFailedError."""
+        super().__init__(message)
+        self.is_quota = is_quota
+
+
 class APIClientError(Exception):
     """Base class for client errors that should NOT trigger retry (Fail Fast)."""
 

--- a/tests/e2e/test_review_flow.py
+++ b/tests/e2e/test_review_flow.py
@@ -38,6 +38,7 @@ class TestReviewFlow:
         settings.google_api_keys = ["ai-key"]
         settings.gemini_model = "gemini-pro"
         settings.gemini_model_fallback = "gemini-2.5-flash"
+        settings.fallback_models = ["gemini-2.5-flash"]
         settings.review_max_files = 5
         settings.review_max_diff_lines = 10
         settings.review_max_comment_chars = 3000
@@ -277,6 +278,7 @@ class TestDiscoveryIntegration:
         settings.google_api_keys = ["ai-key"]
         settings.gemini_model = "gemini-pro"
         settings.gemini_model_fallback = "gemini-2.5-flash"
+        settings.fallback_models = ["gemini-2.5-flash"]
         settings.review_max_files = 5
         settings.review_max_diff_lines = 10
         settings.review_max_comment_chars = 3000

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -84,6 +84,7 @@ def make_mock_settings(**overrides: object) -> Mock:
     settings.google_api_keys = ["test-key-for-unit-tests"]
     settings.gemini_model = "gemini-test"
     settings.gemini_model_fallback = "gemini-2.5-flash"
+    settings.fallback_models = ["gemini-2.5-flash"]
     settings.review_max_files = 20
     settings.review_max_diff_lines = 500
     settings.review_split_threshold = 30_000

--- a/tests/integration/test_gemini.py
+++ b/tests/integration/test_gemini.py
@@ -31,6 +31,7 @@ from ai_reviewer.integrations.gemini import (
     calculate_cost,
 )
 from ai_reviewer.utils.retry import (
+    AllModelsFailedError,
     AuthenticationError,
     QuotaExhaustedError,
     RateLimitError,
@@ -122,6 +123,7 @@ class TestAnalyzeCodeChanges:
         settings.google_api_keys = ["test-key"]
         settings.gemini_model = "gemini-pro"
         settings.gemini_model_fallback = "gemini-2.5-flash"
+        settings.fallback_models = ["gemini-2.5-flash"]
         settings.review_max_files = 5
         settings.review_max_diff_lines = 10
         settings.review_split_threshold = 30_000
@@ -275,6 +277,7 @@ class TestAnalyzeCodeChanges:
         """Test that ServerError propagates when fallback is disabled."""
         mock_build_prompt.return_value = "prompt"
         mock_settings.gemini_model_fallback = None
+        mock_settings.fallback_models = []
         mock_provider_cls.return_value.generate.side_effect = ServerError("503")
 
         with pytest.raises(ServerError):
@@ -310,14 +313,14 @@ class TestAnalyzeCodeChanges:
 
     @patch("ai_reviewer.integrations.gemini.RotatingGeminiProvider")
     @patch("ai_reviewer.integrations.gemini.build_review_prompt")
-    def test_both_models_exhausted_raises_quota_error(
+    def test_all_models_exhausted_raises_all_models_failed(
         self,
         mock_build_prompt: MagicMock,
         mock_provider_cls: MagicMock,
         mock_context: ReviewContext,
         mock_settings: Settings,
     ) -> None:
-        """Test that QuotaExhaustedError with clear message when both models fail."""
+        """Test AllModelsFailedError with is_quota=True when all models hit quota."""
         mock_build_prompt.return_value = "prompt"
 
         primary = Mock()
@@ -327,12 +330,38 @@ class TestAnalyzeCodeChanges:
         primary.generate.side_effect = QuotaExhaustedError("primary quota exceeded")
         fallback.generate.side_effect = QuotaExhaustedError("fallback quota exceeded")
 
-        with pytest.raises(QuotaExhaustedError, match="Both models failed"):
+        with pytest.raises(AllModelsFailedError, match="All 2 model") as exc_info:
             analyze_code_changes(mock_context, mock_settings)
+        assert exc_info.value.is_quota is True
 
     @patch("ai_reviewer.integrations.gemini.RotatingGeminiProvider")
     @patch("ai_reviewer.integrations.gemini.build_review_prompt")
-    def test_both_models_exhausted_message_contains_model_names(
+    def test_all_models_exhausted_server_error_not_quota(
+        self,
+        mock_build_prompt: MagicMock,
+        mock_provider_cls: MagicMock,
+        mock_context: ReviewContext,
+        mock_settings: Settings,
+    ) -> None:
+        """Test AllModelsFailedError with is_quota=False on mixed errors."""
+        mock_build_prompt.return_value = "prompt"
+
+        primary = Mock()
+        fallback = Mock()
+        mock_provider_cls.side_effect = [primary, fallback]
+
+        primary.generate.side_effect = ServerError("503 overloaded")
+        fallback.generate.side_effect = ServerError("503 overloaded")
+
+        with pytest.raises(
+            AllModelsFailedError, match=r"gemini-pro.*gemini-2\.5-flash"
+        ) as exc_info:
+            analyze_code_changes(mock_context, mock_settings)
+        assert exc_info.value.is_quota is False
+
+    @patch("ai_reviewer.integrations.gemini.RotatingGeminiProvider")
+    @patch("ai_reviewer.integrations.gemini.build_review_prompt")
+    def test_all_models_exhausted_message_contains_model_names(
         self,
         mock_build_prompt: MagicMock,
         mock_provider_cls: MagicMock,
@@ -349,7 +378,7 @@ class TestAnalyzeCodeChanges:
         primary.generate.side_effect = QuotaExhaustedError("exhausted")
         fallback.generate.side_effect = ServerError("503 overloaded")
 
-        with pytest.raises(QuotaExhaustedError, match=r"gemini-pro.*gemini-2\.5-flash"):
+        with pytest.raises(AllModelsFailedError, match=r"gemini-pro.*gemini-2\.5-flash"):
             analyze_code_changes(mock_context, mock_settings)
 
     @patch("ai_reviewer.integrations.gemini.RotatingGeminiProvider")
@@ -385,7 +414,7 @@ class TestReExports:
 
     def test_gemini_pricing_reexported(self) -> None:
         """Test that GEMINI_PRICING is re-exported."""
-        assert "gemini-3-flash-preview" in GEMINI_PRICING
+        assert "gemini-3.1-flash-preview" in GEMINI_PRICING
 
     def test_default_model_reexported(self) -> None:
         """Test that DEFAULT_MODEL is re-exported."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -45,7 +45,9 @@ class TestSettings:
             assert settings.google_api_key.get_secret_value() == "AIza_test_key_12345"
             # Check defaults
             assert settings.gemini_model == "gemini-2.5-flash"
-            assert settings.gemini_model_fallback == "gemini-3-flash-preview"
+            assert settings.gemini_model_fallback == (
+                "gemini-3.1-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview"
+            )
             assert settings.log_level == "INFO"
             assert settings.review_max_files == 20
             assert settings.review_max_diff_lines == 500

--- a/tests/unit/test_llm/test_gemini.py
+++ b/tests/unit/test_llm/test_gemini.py
@@ -521,7 +521,7 @@ class TestCalculateCost:
     def test_pricing_table_has_expected_models(self) -> None:
         """Test that GEMINI_PRICING contains expected models."""
         expected = [
-            "gemini-3-flash-preview",
+            "gemini-3.1-flash-preview",
             "gemini-2.5-flash",
             "gemini-2.0-flash",
             "gemini-1.5-flash",

--- a/tests/unit/test_reviewer.py
+++ b/tests/unit/test_reviewer.py
@@ -297,6 +297,7 @@ def _make_settings() -> Mock:
     settings.google_api_keys = ["test-key"]
     settings.gemini_model = "gemini-pro"
     settings.gemini_model_fallback = "gemini-2.5-flash"
+    settings.fallback_models = ["gemini-2.5-flash"]
     settings.discovery_enabled = True
     settings.discovery_timeout = 30
     settings.language_mode = LanguageMode.FIXED
@@ -541,28 +542,42 @@ class TestPostErrorComment:
         assert "Review Failed" in comment
         assert "something broke" in comment
 
-    def test_quota_exhausted_uses_quota_heading(self) -> None:
-        """Test that QuotaExhaustedError produces 'Quota Exhausted' comment."""
-        from ai_reviewer.utils.retry import QuotaExhaustedError
+    def test_all_models_failed_quota_uses_quota_heading(self) -> None:
+        """Test AllModelsFailedError with is_quota=True shows 'Quota Exhausted'."""
+        from ai_reviewer.utils.retry import AllModelsFailedError
 
         provider = MagicMock(spec=GitProvider)
-        error = QuotaExhaustedError("Both models failed — primary and fallback")
+        error = AllModelsFailedError("All 2 model(s) failed", is_quota=True)
 
         _post_error_comment(provider, "owner/repo", 1, error)
 
         args, _ = provider.post_comment.call_args
         comment = args[2]
         assert "Quota Exhausted" in comment
-        assert "Both models failed" in comment
         assert "Gemini API plan" in comment
+
+    def test_all_models_failed_server_error_uses_unavailable_heading(self) -> None:
+        """Test AllModelsFailedError with is_quota=False shows 'All Models Unavailable'."""
+        from ai_reviewer.utils.retry import AllModelsFailedError
+
+        provider = MagicMock(spec=GitProvider)
+        error = AllModelsFailedError("All 2 model(s) failed: ServerError", is_quota=False)
+
+        _post_error_comment(provider, "owner/repo", 1, error)
+
+        args, _ = provider.post_comment.call_args
+        comment = args[2]
+        assert "All Models Unavailable" in comment
+        assert "server errors or rate limits" in comment
+        assert "Review Failed" not in comment
 
     def test_quota_comment_does_not_say_review_failed(self) -> None:
         """Test that quota comment uses softer wording, not 'Review Failed'."""
-        from ai_reviewer.utils.retry import QuotaExhaustedError
+        from ai_reviewer.utils.retry import AllModelsFailedError
 
         provider = MagicMock(spec=GitProvider)
 
-        _post_error_comment(provider, "owner/repo", 1, QuotaExhaustedError("quota exceeded"))
+        _post_error_comment(provider, "owner/repo", 1, AllModelsFailedError("quota", is_quota=True))
 
         args, _ = provider.post_comment.call_args
         assert "Review Failed" not in args[2]

--- a/tests/unit/test_split_review.py
+++ b/tests/unit/test_split_review.py
@@ -54,6 +54,7 @@ def _make_settings(**overrides: object) -> Mock:
     settings.review_enable_dialogue = True
     settings.gemini_model = "gemini-test"
     settings.gemini_model_fallback = None
+    settings.fallback_models = []
     settings.google_api_key = Mock()
     settings.google_api_key.get_secret_value.return_value = "test-key"
     settings.google_api_keys = ["test-key"]


### PR DESCRIPTION
  ## Summary

  - **Ланцюжок fallback-моделей замість однієї:** тепер `gemini_model_fallback` приймає список через кому.
  Дефолтний ланцюжок: `gemini-2.5-flash → gemini-3.1-flash-preview → gemini-2.5-flash-lite →
  gemini-3.1-flash-lite-preview`
  - **Виправлено misleading помилку:** раніше при 503 ServerError від обох моделей користувач бачив "API Quota
  Exhausted", хоча це серверна помилка, а не quota. Тепер: новий `AllModelsFailedError` з прапорцем `is_quota` —
  коментар в MR чітко розрізняє "All Models Unavailable" (серверні помилки) та "API Quota Exhausted" (реальне
  вичерпання квоти)
  - **Оновлено моделі Gemini:** прибрано застарілу `gemini-3-flash-preview`, додано актуальні 3.1 та 2.5-flash-lite
   в pricing table, docs (6 мов), action.yml, README, .env.example

  ## Changes

  ### Core
  - `retry.py` — новий `AllModelsFailedError(message, is_quota=bool)`
  - `gemini.py` — `_call_llm()` рефакторинг: ітерація по ланцюжку моделей замість nested try/except
  - `reviewer.py` — `_post_error_comment()` розрізняє quota vs server errors
  - `config.py` — `Settings.fallback_models` property (comma-separated parsing)
  - `llm/gemini.py` — `GEMINI_PRICING` оновлено (3.1 models)

  ### Docs & Config
  - action.yml, .env.example — нові дефолти fallback chain
  - 18 doc-файлів (6 мов) — оновлено моделі, таблиці, curl-приклади
  - README.md, examples/README.md — синхронізовано

  ## Test plan
  - [x] 1088 тестів пройшло (ruff clean, mypy clean)
  - [x] Нові тести: `test_all_models_exhausted_raises_all_models_failed`,
  `test_all_models_exhausted_server_error_not_quota`, `test_all_models_exhausted_message_contains_model_names`
  - [x] Існуючі тести оновлено під `AllModelsFailedError` та нові дефолти