### PR TITLE
fix: replace nonexistent gemini-3.1-flash-preview and rotate on 404

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ GOOGLE_API_KEY=
 
 # Gemini model (default: gemini-2.5-flash)
 # GEMINI_MODEL=gemini-2.5-flash
-# GEMINI_MODEL_FALLBACK=gemini-3.1-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview
+# GEMINI_MODEL_FALLBACK=gemini-3-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview
 
 # =============================================================================
 # Git Platform (one required)

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ inputs:
   gemini_model_fallback:
     description: 'Comma-separated fallback model chain (empty to disable)'
     required: false
-    default: 'gemini-3.1-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview'
+    default: 'gemini-3-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview'
   log_level:
     description: 'Log level (DEBUG, INFO, WARNING, ERROR)'
     required: false

--- a/docs/de/configuration.md
+++ b/docs/de/configuration.md
@@ -79,12 +79,12 @@ mistral-large → mistral-small → gemini-2.5-flash → gemini-2.5-flash-lite
 | Variable | Beschreibung | Standard |
 |----------|--------------|----------|
 | `AI_REVIEWER_GEMINI_MODEL` | Primäres Gemini-Modell | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback-Modellkette (kommagetrennt) | `gemini-3.1-flash-preview,...` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback-Modellkette (kommagetrennt) | `gemini-3-flash-preview,...` |
 
 | Modell | Beschreibung | Kosten |
 |--------|--------------|--------|
 | `gemini-2.5-flash` | Schnell, stabil, mit Reasoning (Standard) | $0.075 / 1M Input |
-| `gemini-3.1-flash-preview` | Frontier-Klasse Flash (Vorschau) | $0.075 / 1M Input |
+| `gemini-3-flash-preview` | Frontier-Klasse Flash (Vorschau) | $0.075 / 1M Input |
 | `gemini-2.5-flash-lite` | Schnellste und günstigste in 2.5 | $0.01875 / 1M Input |
 | `gemini-2.5-pro` | Leistungsstärkste, tiefes Reasoning | $1.25 / 1M Input |
 

--- a/docs/de/github.md
+++ b/docs/de/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Max. MR-Kommentarzeichen im Prompt | `3000` |
 | `review_include_bot_comments` | Bot-Kommentare in Prompt einbeziehen | `true` |
 | `review_post_inline_comments` | Inline-Kommentare an Codezeilen posten | `true` |
-| `gemini_model_fallback` | Fallback-Modellkette (durch Komma getrennt) | `gemini-3.1-flash-preview` |
+| `gemini_model_fallback` | Fallback-Modellkette (durch Komma getrennt) | `gemini-3-flash-preview` |
 | `review_enable_dialogue` | Kommentare in Dialoge gruppieren | `true` |
 | `discovery_enabled` | Project Discovery aktivieren | `true` |
 | `discovery_verbose` | Discovery-Kommentar immer posten | `false` |

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -79,12 +79,12 @@ mistral-large → mistral-small → gemini-2.5-flash → gemini-2.5-flash-lite
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `AI_REVIEWER_GEMINI_MODEL` | Primary Gemini model | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3.1-flash-preview,...` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Fallback model chain (comma-separated) | `gemini-3-flash-preview,...` |
 
 | Model | Description | Cost |
 |-------|-------------|------|
 | `gemini-2.5-flash` | Fast, stable, reasoning (default) | $0.075 / 1M input |
-| `gemini-3.1-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
+| `gemini-3-flash-preview` | Frontier-class flash (preview) | $0.075 / 1M input |
 | `gemini-2.5-flash-lite` | Fastest and cheapest in 2.5 | $0.01875 / 1M input |
 | `gemini-2.5-pro` | Most powerful, deep reasoning | $1.25 / 1M input |
 

--- a/docs/en/github.md
+++ b/docs/en/github.md
@@ -226,7 +226,7 @@ jobs:
 | `llm_fallback_provider` | Fallback LLM provider | _(none)_ |
 | `github_token` | GitHub token | `${{ github.token }}` |
 | `gemini_model` | Gemini model | `gemini-2.5-flash` |
-| `gemini_model_fallback` | Gemini fallback model chain | `gemini-3.1-flash-preview,...` |
+| `gemini_model_fallback` | Gemini fallback model chain | `gemini-3-flash-preview,...` |
 | `mistral_model` | Mistral model | `mistral-large-latest` |
 | `mistral_model_fallback` | Mistral fallback model chain | _(none)_ |
 | `mistral_api_url` | Custom Mistral API URL (e.g. `https://codestral.mistral.ai`) | _(none)_ |

--- a/docs/es/configuration.md
+++ b/docs/es/configuration.md
@@ -79,12 +79,12 @@ mistral-large → mistral-small → gemini-2.5-flash → gemini-2.5-flash-lite
 | Variable | Descripción | Por defecto |
 |----------|-------------|-------------|
 | `AI_REVIEWER_GEMINI_MODEL` | Modelo primario de Gemini | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Cadena de modelos de respaldo (separados por comas) | `gemini-3.1-flash-preview,...` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Cadena de modelos de respaldo (separados por comas) | `gemini-3-flash-preview,...` |
 
 | Modelo | Descripción | Costo |
 |--------|-------------|-------|
 | `gemini-2.5-flash` | Rápido, estable, con razonamiento (predeterminado) | $0.075 / 1M entrada |
-| `gemini-3.1-flash-preview` | Flash de clase frontier (vista previa) | $0.075 / 1M entrada |
+| `gemini-3-flash-preview` | Flash de clase frontier (vista previa) | $0.075 / 1M entrada |
 | `gemini-2.5-flash-lite` | El más rápido y económico en 2.5 | $0.01875 / 1M entrada |
 | `gemini-2.5-pro` | El más potente, razonamiento profundo | $1.25 / 1M entrada |
 

--- a/docs/es/github.md
+++ b/docs/es/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Máx. caracteres de comentario MR en el prompt | `3000` |
 | `review_include_bot_comments` | Incluir comentarios de bots en el prompt | `true` |
 | `review_post_inline_comments` | Publicar comentarios inline en líneas | `true` |
-| `gemini_model_fallback` | Cadena de modelos de respaldo (separados por comas) | `gemini-3.1-flash-preview` |
+| `gemini_model_fallback` | Cadena de modelos de respaldo (separados por comas) | `gemini-3-flash-preview` |
 | `review_enable_dialogue` | Agrupar comentarios en diálogos | `true` |
 | `discovery_enabled` | Activar project discovery | `true` |
 | `discovery_verbose` | Publicar siempre comentario de discovery | `false` |

--- a/docs/it/configuration.md
+++ b/docs/it/configuration.md
@@ -79,12 +79,12 @@ mistral-large → mistral-small → gemini-2.5-flash → gemini-2.5-flash-lite
 | Variabile | Descrizione | Default |
 |-----------|-------------|---------|
 | `AI_REVIEWER_GEMINI_MODEL` | Modello Gemini primario | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Catena di modelli di fallback (separati da virgola) | `gemini-3.1-flash-preview,...` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Catena di modelli di fallback (separati da virgola) | `gemini-3-flash-preview,...` |
 
 | Modello | Descrizione | Costo |
 |---------|-------------|-------|
 | `gemini-2.5-flash` | Veloce, stabile, con ragionamento (predefinito) | $0.075 / 1M input |
-| `gemini-3.1-flash-preview` | Flash di classe frontier (anteprima) | $0.075 / 1M input |
+| `gemini-3-flash-preview` | Flash di classe frontier (anteprima) | $0.075 / 1M input |
 | `gemini-2.5-flash-lite` | Il piu veloce e economico in 2.5 | $0.01875 / 1M input |
 | `gemini-2.5-pro` | Piu potente, con ragionamento profondo | $1.25 / 1M input |
 

--- a/docs/it/github.md
+++ b/docs/it/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Max caratteri commento MR nel prompt | `3000` |
 | `review_include_bot_comments` | Includi commenti bot nel prompt | `true` |
 | `review_post_inline_comments` | Pubblica commenti inline sulle righe | `true` |
-| `gemini_model_fallback` | Catena di modelli di fallback (separati da virgola) | `gemini-3.1-flash-preview` |
+| `gemini_model_fallback` | Catena di modelli di fallback (separati da virgola) | `gemini-3-flash-preview` |
 | `review_enable_dialogue` | Raggruppare i commenti in dialoghi | `true` |
 | `discovery_enabled` | Attivare project discovery | `true` |
 | `discovery_verbose` | Pubblicare sempre il commento discovery | `false` |

--- a/docs/sr/configuration.md
+++ b/docs/sr/configuration.md
@@ -79,12 +79,12 @@ mistral-large → mistral-small → gemini-2.5-flash → gemini-2.5-flash-lite
 | Varijabla | Opis | Podrazumijevano |
 |----------|------|---------|
 | `AI_REVIEWER_GEMINI_MODEL` | Primarni Gemini model | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Lanac rezervnih modela (odvojenih zarezima) | `gemini-3.1-flash-preview,...` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Lanac rezervnih modela (odvojenih zarezima) | `gemini-3-flash-preview,...` |
 
 | Model | Opis | Cijena |
 |-------|------|--------|
 | `gemini-2.5-flash` | Brz, stabilan, sa sposobnošću rasuđivanja (podrazumijevano) | $0.075 / 1M ulaz |
-| `gemini-3.1-flash-preview` | Frontier-klasa flash (pregled) | $0.075 / 1M ulaz |
+| `gemini-3-flash-preview` | Frontier-klasa flash (pregled) | $0.075 / 1M ulaz |
 | `gemini-2.5-flash-lite` | Najbrži i najjeftiniji u 2.5 | $0.01875 / 1M ulaz |
 | `gemini-2.5-pro` | Najmoćniji, sa dubokim rasuđivanjem | $1.25 / 1M ulaz |
 

--- a/docs/sr/github.md
+++ b/docs/sr/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Maks. znakova komentara MR-a u promptu | `3000` |
 | `review_include_bot_comments` | Uključi komentare botova u prompt | `true` |
 | `review_post_inline_comments` | Objavi inline komentare na linijama | `true` |
-| `gemini_model_fallback` | Lanac rezervnih modela (odvojenih zarezima) | `gemini-3.1-flash-preview` |
+| `gemini_model_fallback` | Lanac rezervnih modela (odvojenih zarezima) | `gemini-3-flash-preview` |
 | `review_enable_dialogue` | Grupisati komentare u dijaloge | `true` |
 | `discovery_enabled` | Aktivirati project discovery | `true` |
 | `discovery_verbose` | Uvijek objaviti discovery komentar | `false` |

--- a/docs/uk/configuration.md
+++ b/docs/uk/configuration.md
@@ -79,12 +79,12 @@ mistral-large → mistral-small → gemini-2.5-flash → gemini-2.5-flash-lite
 | Змінна | Опис | Default |
 |--------|------|---------|
 | `AI_REVIEWER_GEMINI_MODEL` | Основна модель Gemini | `gemini-2.5-flash` |
-| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Ланцюжок fallback-моделей (через кому) | `gemini-3.1-flash-preview,...` |
+| `AI_REVIEWER_GEMINI_MODEL_FALLBACK` | Ланцюжок fallback-моделей (через кому) | `gemini-3-flash-preview,...` |
 
 | Модель | Опис | Ціна |
 |--------|------|------|
 | `gemini-2.5-flash` | Швидка, стабільна, з reasoning (за замовчуванням) | $0.075 / 1M input |
-| `gemini-3.1-flash-preview` | Frontier-клас flash (preview) | $0.075 / 1M input |
+| `gemini-3-flash-preview` | Frontier-клас flash (preview) | $0.075 / 1M input |
 | `gemini-2.5-flash-lite` | Найшвидша і найдешевша в 2.5 | $0.01875 / 1M input |
 | `gemini-2.5-pro` | Найпотужніша, з глибоким reasoning | $1.25 / 1M input |
 

--- a/docs/uk/github.md
+++ b/docs/uk/github.md
@@ -226,7 +226,7 @@ jobs:
 | `review_max_comment_chars` | Макс. символів коментаря MR у промпті | `3000` |
 | `review_include_bot_comments` | Включати коментарі ботів у промпт | `true` |
 | `review_post_inline_comments` | Публікувати inline коментарі до рядків | `true` |
-| `gemini_model_fallback` | Ланцюжок fallback-моделей (через кому) | `gemini-3.1-flash-preview` |
+| `gemini_model_fallback` | Ланцюжок fallback-моделей (через кому) | `gemini-3-flash-preview` |
 | `review_enable_dialogue` | Групувати коментарі в діалоги | `true` |
 | `discovery_enabled` | Увімкнути project discovery | `true` |
 | `discovery_verbose` | Завжди публікувати discovery коментар | `false` |

--- a/examples/README.md
+++ b/examples/README.md
@@ -107,5 +107,5 @@ The reviewer displays estimated costs in the review footer. Typical costs:
 | Model | ~2000 tokens | ~10000 tokens |
 |-------|--------------|---------------|
 | gemini-2.5-flash | ~$0.0002 | ~$0.001 |
-| gemini-3.1-flash-preview | ~$0.0002 | ~$0.001 |
+| gemini-3-flash-preview | ~$0.0002 | ~$0.001 |
 | gemini-2.5-pro | ~$0.005 | ~$0.025 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-reviewbot"
-version = "1.0.0b12"
+version = "1.0.0b13"
 description = "AI-powered code review agent for CI/CD pipelines"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/ai_reviewer/core/config.py
+++ b/src/ai_reviewer/core/config.py
@@ -250,7 +250,7 @@ class Settings(BaseSettings):
         description="Gemini model to use for analysis",
     )
     gemini_model_fallback: str | None = Field(
-        default="gemini-3.1-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview",
+        default="gemini-3-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview",
         validation_alias=AliasChoices("AI_REVIEWER_GEMINI_MODEL_FALLBACK", "GEMINI_MODEL_FALLBACK"),
         description="Comma-separated fallback model chain (empty to disable)",
     )

--- a/src/ai_reviewer/integrations/gemini.py
+++ b/src/ai_reviewer/integrations/gemini.py
@@ -33,6 +33,7 @@ from ai_reviewer.llm.gemini import (
 from ai_reviewer.llm.router import create_router
 from ai_reviewer.utils.retry import (
     AllModelsFailedError,
+    NotFoundError,
     QuotaExhaustedError,
     RateLimitError,
     ServerError,
@@ -235,7 +236,7 @@ def _call_llm(
                 response_schema=ReviewResult,
             )
             break  # success
-        except (ServerError, RateLimitError, QuotaExhaustedError) as err:
+        except (ServerError, RateLimitError, QuotaExhaustedError, NotFoundError) as err:
             failures.append((model_name, err))
             logger.warning(
                 "Model %s (%s) failed (%s: %s). %d model(s) remaining.",

--- a/src/ai_reviewer/llm/catalog.py
+++ b/src/ai_reviewer/llm/catalog.py
@@ -62,7 +62,7 @@ DEFAULT_CATALOG: tuple[ModelCard, ...] = (
         output_price_per_mtok=0.40,
     ),
     ModelCard(
-        name="gemini-3.1-flash-preview",
+        name="gemini-3-flash-preview",
         operator=Operator.GOOGLE,
         tags=frozenset({_L, _F, _SO, _LC}),
         context_window=1_048_576,

--- a/src/ai_reviewer/llm/gemini.py
+++ b/src/ai_reviewer/llm/gemini.py
@@ -27,6 +27,7 @@ from ai_reviewer.llm.base import LLMProvider, LLMResponse
 from ai_reviewer.utils.retry import (
     AuthenticationError,
     ForbiddenError,
+    NotFoundError,
     QuotaExhaustedError,
     RateLimitError,
     ServerError,
@@ -42,8 +43,8 @@ logger = logging.getLogger(__name__)
 # Gemini pricing per 1M tokens (as of February 2026)
 # https://ai.google.dev/pricing
 GEMINI_PRICING: dict[str, dict[str, float]] = {
-    # Gemini 3.1 (preview)
-    "gemini-3.1-flash-preview": {"input": 0.075, "output": 0.30},
+    # Gemini 3.x (preview)
+    "gemini-3-flash-preview": {"input": 0.075, "output": 0.30},
     "gemini-3.1-flash-lite-preview": {"input": 0.01875, "output": 0.075},
     "gemini-3.1-pro-preview": {"input": 1.25, "output": 5.00},
     # Gemini 2.5
@@ -158,10 +159,12 @@ def _match_by_error_message(e: Exception) -> Exception:
         return RateLimitError(f"Gemini: {e}")
     if any(kw in error_msg for kw in ("500", "502", "503", "504", "server error", "deadline")):
         return ServerError(f"Gemini: {e}")
+    if "404" in error_msg or "not_found" in error_msg or "not found" in error_msg:
+        return NotFoundError(f"Gemini: {e}")
     return e
 
 
-def _convert_google_exception(e: Exception) -> Exception:
+def _convert_google_exception(e: Exception) -> Exception:  # noqa: PLR0911
     """Convert Google API exception to the internal exception hierarchy.
 
     Checks concrete ``google.api_core.exceptions`` types first, then
@@ -185,6 +188,9 @@ def _convert_google_exception(e: Exception) -> Exception:
 
     if isinstance(e, google_exceptions.PermissionDenied):
         return ForbiddenError(f"Gemini: {e}")
+
+    if isinstance(e, google_exceptions.NotFound):
+        return NotFoundError(f"Gemini: {e}")
 
     if isinstance(
         e,

--- a/tests/integration/test_gemini.py
+++ b/tests/integration/test_gemini.py
@@ -33,6 +33,7 @@ from ai_reviewer.integrations.gemini import (
 from ai_reviewer.utils.retry import (
     AllModelsFailedError,
     AuthenticationError,
+    NotFoundError,
     QuotaExhaustedError,
     RateLimitError,
     ServerError,
@@ -272,6 +273,46 @@ class TestAnalyzeCodeChanges:
 
     @patch("ai_reviewer.integrations.gemini.create_router")
     @patch("ai_reviewer.integrations.gemini.build_review_prompt")
+    def test_fallback_on_not_found(
+        self,
+        mock_build_prompt: MagicMock,
+        mock_create_router: MagicMock,
+        mock_context: ReviewContext,
+        mock_settings: Settings,
+    ) -> None:
+        """Test that NotFoundError (404 unknown model) triggers fallback."""
+        mock_build_prompt.return_value = "prompt"
+
+        primary_provider = Mock()
+        fallback_provider = Mock()
+
+        mock_router = mock_create_router.return_value
+        mock_router.create_provider.side_effect = [primary_provider, fallback_provider]
+
+        primary_provider.generate.side_effect = NotFoundError(
+            "Gemini: 404 NOT_FOUND. models/bogus-model is not found"
+        )
+
+        expected = ReviewResult(summary="Recovered")
+        mock_resp = Mock()
+        mock_resp.content = expected
+        mock_resp.model_name = "gemini-2.5-flash"
+        mock_resp.prompt_tokens = 0
+        mock_resp.completion_tokens = 0
+        mock_resp.total_tokens = 0
+        mock_resp.latency_ms = 0
+        mock_resp.estimated_cost_usd = 0.0
+        fallback_provider.generate.return_value = mock_resp
+
+        result = analyze_code_changes(mock_context, mock_settings)
+
+        assert result.summary == "Recovered"
+        assert result.metrics is not None
+        assert "NotFoundError" in result.metrics.fallback_reason  # type: ignore[operator]
+        assert mock_router.create_provider.call_count == 2
+
+    @patch("ai_reviewer.integrations.gemini.create_router")
+    @patch("ai_reviewer.integrations.gemini.build_review_prompt")
     def test_no_fallback_on_auth_error(
         self,
         mock_build_prompt: MagicMock,
@@ -448,7 +489,7 @@ class TestReExports:
 
     def test_gemini_pricing_reexported(self) -> None:
         """Test that GEMINI_PRICING is re-exported."""
-        assert "gemini-3.1-flash-preview" in GEMINI_PRICING
+        assert "gemini-3-flash-preview" in GEMINI_PRICING
 
     def test_default_model_reexported(self) -> None:
         """Test that DEFAULT_MODEL is re-exported."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -46,7 +46,7 @@ class TestSettings:
             # Check defaults
             assert settings.gemini_model == "gemini-2.5-flash"
             assert settings.gemini_model_fallback == (
-                "gemini-3.1-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview"
+                "gemini-3-flash-preview,gemini-2.5-flash-lite,gemini-3.1-flash-lite-preview"
             )
             assert settings.log_level == "INFO"
             assert settings.review_max_files == 20

--- a/tests/unit/test_llm/test_gemini.py
+++ b/tests/unit/test_llm/test_gemini.py
@@ -26,6 +26,7 @@ from ai_reviewer.llm.gemini import (
 from ai_reviewer.utils.retry import (
     AuthenticationError,
     ForbiddenError,
+    NotFoundError,
     QuotaExhaustedError,
     RateLimitError,
     ServerError,
@@ -306,6 +307,22 @@ class TestConvertGoogleException:
         result = _convert_google_exception(exc)
         assert isinstance(result, ForbiddenError)
 
+    def test_not_found_becomes_not_found_error(self) -> None:
+        """Test NotFound (unknown model) → NotFoundError."""
+        exc = google_exceptions.NotFound("models/bogus is not found")
+        result = _convert_google_exception(exc)
+        assert isinstance(result, NotFoundError)
+
+    def test_404_in_message_becomes_not_found_error(self) -> None:
+        """Test fallback: '404 NOT_FOUND' in message → NotFoundError.
+
+        Covers genai_errors.ClientError whose message starts with the
+        textual status (e.g. ``404 NOT_FOUND. {...}``).
+        """
+        exc = Exception("404 NOT_FOUND. models/gemini-9.9 is not found for v1beta")
+        result = _convert_google_exception(exc)
+        assert isinstance(result, NotFoundError)
+
     def test_internal_server_error_becomes_server_error(self) -> None:
         """Test InternalServerError → ServerError."""
         exc = google_exceptions.InternalServerError("Oops")
@@ -521,7 +538,7 @@ class TestCalculateCost:
     def test_pricing_table_has_expected_models(self) -> None:
         """Test that GEMINI_PRICING contains expected models."""
         expected = [
-            "gemini-3.1-flash-preview",
+            "gemini-3-flash-preview",
             "gemini-2.5-flash",
             "gemini-2.0-flash",
             "gemini-1.5-flash",

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "ai-reviewbot"
-version = "1.0.0b9"
+version = "1.0.0b13"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-core" },


### PR DESCRIPTION
Body:
  ## Summary

  - Replace the nonexistent `gemini-3.1-flash-preview` model ID with the real `gemini-3-flash-preview` across config
  defaults, catalog, pricing, `action.yml`, `.env.example`, all 6 docs locales, examples, and tests.
  - Convert Google API `404 NOT_FOUND` (typed `google_exceptions.NotFound` and message-based) to `NotFoundError`, and
  add `NotFoundError` to the rotatable tuple in `_call_with_router_fallback` so unknown models are skipped instead of
  crashing.
  - Bump version to `1.0.0b13`.

  ## Why

  Reviews failed with `404 NOT_FOUND. models/gemini-3.1-flash-preview is not found`. Two bugs: (1) typo — Google's
  actual 3.x flash variants are `gemini-3-flash-preview` (3.0) and `gemini-3.1-flash-lite-preview` (lite). (2) The
  chain dispatcher only caught `ServerError`/`RateLimitError`/`QuotaExhaustedError`, so 404 escaped without trying the
  next model.

  ## Test plan

  - [x] `uv run pytest` — 1219 passed (+3 new)
  - [x] `uv run ruff check` — clean
  - [x] `uv run mypy src/` — clean
  - [ ] Після merge: tag `v1.0.0b13`, оновити `v1`, перевірити PyPI + Docker
